### PR TITLE
Add links to admin form documentation.

### DIFF
--- a/src/Plugin/Field/FieldWidget/TextDateWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextDateWidget.php
@@ -38,7 +38,8 @@ class TextDateWidget extends WidgetBase {
     $element = parent::settingsForm($form, $form_state);
     $element['date_format'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('PHP DateTime Format String (http://php.net/manual/en/datetime.createfromformat.php).'),
+      '#title' => $this->t('PHP DateTime Format String.'),
+      '#description' => $this->t('See <a href="@phpdate">PHP DateTime Documentation</a> for details.', array('@phpdate' => 'http://php.net/manual/en/datetime.createfromformat.php')),
       '#default_value' => $this->getSetting('date_format'),
     ];
     $element['strict_dates'] = [

--- a/src/Plugin/Field/FieldWidget/TextDateWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextDateWidget.php
@@ -39,7 +39,7 @@ class TextDateWidget extends WidgetBase {
     $element['date_format'] = [
       '#type' => 'textfield',
       '#title' => $this->t('PHP DateTime Format String.'),
-      '#description' => $this->t('See <a href="@phpdate">PHP DateTime Documentation</a> for details.', array('@phpdate' => 'http://php.net/manual/en/datetime.createfromformat.php')),
+      '#description' => $this->t('See <a href="@phpdate" target="_blank">PHP DateTime Documentation</a> for details.', array('@phpdate' => 'http://php.net/manual/en/datetime.createfromformat.php')),
       '#default_value' => $this->getSetting('date_format'),
     ];
     $element['strict_dates'] = [

--- a/src/Plugin/Field/FieldWidget/TextDateWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextDateWidget.php
@@ -39,7 +39,7 @@ class TextDateWidget extends WidgetBase {
     $element['date_format'] = [
       '#type' => 'textfield',
       '#title' => $this->t('PHP DateTime Format String.'),
-      '#description' => $this->t('See <a href="@phpdate" target="_blank">PHP DateTime Documentation</a> for details.', array('@phpdate' => 'http://php.net/manual/en/datetime.createfromformat.php')),
+      '#description' => $this->t('See <a href="@phpdate" target="_blank">PHP DateTime Documentation</a> for details.', ['@phpdate' => 'http://php.net/manual/en/datetime.createfromformat.php']),
       '#default_value' => $this->getSetting('date_format'),
     ];
     $element['strict_dates'] = [

--- a/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
@@ -54,7 +54,7 @@ class TextEDTFWidget extends WidgetBase {
        '#type' => 'markup',
        '#prefix' => '<div>',
        '#suffix' => '</div>',
-       '#markup' => $this->t('See <a href="@locedtf" target="_blank">Library of Congress EDTF Draft Submission</a> for details on formatting options.', array('@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html')),
+       '#markup' => $this->t('See <a href="@locedtf" target="_blank">Library of Congress EDTF Draft Submission</a> for details on formatting options.', ['@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html']),
     ];
     $element['strict_dates'] = [
       '#type' => 'checkbox',

--- a/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
@@ -50,6 +50,12 @@ class TextEDTFWidget extends WidgetBase {
         checking. (For example, "1984~?" will be checked as "1984".)'
     );
     $element = parent::settingsForm($form, $form_state);
+    $element['description'] = [
+       '#type' => 'markup',
+       '#prefix' => '<div>',
+       '#suffix' => '</div>',
+       '#markup' => $this->t('See <a href="@locedtf">Library of Congress EDTF Draft Submission</a> for details on formatting options.', array('@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html')),
+    ];
     $element['strict_dates'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Ensure provided date values are valid.'),

--- a/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/TextEDTFWidget.php
@@ -54,7 +54,7 @@ class TextEDTFWidget extends WidgetBase {
        '#type' => 'markup',
        '#prefix' => '<div>',
        '#suffix' => '</div>',
-       '#markup' => $this->t('See <a href="@locedtf">Library of Congress EDTF Draft Submission</a> for details on formatting options.', array('@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html')),
+       '#markup' => $this->t('See <a href="@locedtf" target="_blank">Library of Congress EDTF Draft Submission</a> for details on formatting options.', array('@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html')),
     ];
     $element['strict_dates'] = [
       '#type' => 'checkbox',


### PR DESCRIPTION
When I was trying to figure out how the EDTF widget worked, i found a distinct lack of link to the documentation for how to use EDTF. (It was hiding in the code!) I put it in the UI, and also link-i-fied (using D7 patterns because that's what I know) it and the one that was plain text in the Text Date widget.
