### PR TITLE
Remove doc reference to auto_entitylabel, no longer a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Integration project](https://github.com/UNLV-Libraries/archivesspace-drupal) and
 This module requires the following modules:
 
 - [name](https://www.drupal.org/project/name)
-- [auto_entitylabel](https://www.drupal.org/project/auto_entitylabel)
 - [geolocation](https://www.drupal.org/project/geolocation)
 - [token](https://www.drupal.org/project/token)
 


### PR DESCRIPTION
Was removed in 51ed83a.

@seth-shaw-unlv 
