### PR TITLE
Warn about empty typed relation entity references (issue-1489)

### DIFF
--- a/controlled_access_terms.module
+++ b/controlled_access_terms.module
@@ -32,11 +32,27 @@ function controlled_access_terms_jsonld_alter_normalized_array(EntityInterface $
         if ($field_definition->getType() == 'typed_relation') {
           foreach ($entity->get($field)->getValue() as $value) {
             if (empty($value['target_id'])) {
-              \Drupal::logger('controlled_access_terms')->warning("Missing target entity for $field in ".$entity->bundle().' '.$entity->id());
+              \Drupal::logger('controlled_access_terms')->warning("Missing target entity for %field in %entity_type/%id (%bundle)",
+              [
+                '%field' => $field,
+                '%entity_type' => $entity->getEntityTypeId(),
+                '%bundle' => $entity->bundle(),
+                '%id' => $entity->id(),
+              ]);
               continue;
             }
             $predicate = NormalizerBase::escapePrefix($value['rel_type'], $context['namespaces']);
             $referenced_entity = \Drupal::entityTypeManager()->getStorage($field_definition->getSetting('target_type'))->load($value['target_id']);
+            if (empty($referenced_entity)) {
+              \Drupal::logger('controlled_access_terms')->warning("Invalid target entity for %field in %entity_type/%id (%bundle)",
+              [
+                '%field' => $field,
+                '%entity_type' => $entity->getEntityTypeId(),
+                '%bundle' => $entity->bundle(),
+                '%id' => $entity->id(),
+              ]);
+              continue;
+            }
             // We are assuming the first graph is the one corresponding
             // to the node/taxonomy_term we are modifying.
             $normalized['@graph'][0][$predicate][] = [

--- a/controlled_access_terms.module
+++ b/controlled_access_terms.module
@@ -31,6 +31,10 @@ function controlled_access_terms_jsonld_alter_normalized_array(EntityInterface $
       if (!empty($entity->get($field)->getValue())) {
         if ($field_definition->getType() == 'typed_relation') {
           foreach ($entity->get($field)->getValue() as $value) {
+            if (empty($value['target_id'])) {
+              \Drupal::logger('controlled_access_terms')->warning("Missing target entity for $field in ".$entity->bundle().' '.$entity->id());
+              continue;
+            }
             $predicate = NormalizerBase::escapePrefix($value['rel_type'], $context['namespaces']);
             $referenced_entity = \Drupal::entityTypeManager()->getStorage($field_definition->getSetting('target_type'))->load($value['target_id']);
             // We are assuming the first graph is the one corresponding


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1489

# What does this Pull Request do?

Catches an issue where the JSON-LD will WSOD if you accidentally give it a typed relation with an empty entity reference and warns you about it.

# What's new?
* Added sanity check on empty entity references in typed relations during JSON-LD alter which logs a warning.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? You may want to re-index your repository in Fedora if you've been unwittingly loosing data to the error this fixes.

# How should this be tested?

A description of what steps someone could take to:
* Somehow create a typed relation without an entity reference. (I did it by accident with a bad migration.)
* Attempt to view the resulting node's JSON-LD and see a WSOD.
* Apply the PR 
* Attempt to view the node's JSON-LD again and see valid JSON-LD return
* Check your logs. There should be a warning about a missing entity reference in the typed relation field for that node.

# Interested parties
@Islandora/8-x-committers
