### PR TITLE
issues/1533-EDTFUtils-bugs

### DIFF
--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -137,9 +137,10 @@ class EDTFUtils {
     if ($sets) {
       if (strpos($edtf_text, '[') !== FALSE || strpos($edtf_text, '{') !== FALSE) {
         // Test for valid enclosing characters and valid characters inside.
-        $match = preg_match('/^([\[,\{])[\d,\-,X,Y,E,S,.]*([\],\}])$/', $edtf_text);
-        if (!$match || $match[1] !== $match[2]) {
+        $has_match = preg_match('/^([\[\{])[\d\-XYES.,]+([\]\}])$/', $edtf_text, $match);
+        if (!$has_match) {
           $msgs[] = "The set is improperly encoded.";
+          return $msgs;
         }
         // Test each date in set.
         foreach (preg_split('/(,|\.\.)/', trim($edtf_text, '{}[]')) as $date) {
@@ -156,7 +157,7 @@ class EDTFUtils {
         $msgs[] = "Date intervals cannot include times.";
       }
       foreach (explode('/', $edtf_text) as $date) {
-        if (!empty($date) && !$date === '..') {
+        if (!empty($date) && !($date == '..')) {
           $msgs = array_merge($msgs, self::validateDate($date, $strict));
         }
       }


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1533)

# What does this Pull Request do?
Attempts to fix several bugs in EDTFUtils::validate():

Line 140: The regex pattern for a date set should not have the char lists internally separated by commas. Valid multiple date set strings are not matched.
Line 140: I think the string [] should not be considered a properly encoded date string, so I think the date part match group quantity should be changed from * to +.
Line 141: When there is a match, $match[1] and $match[2] will never equal each other. If $has_match is false, that's sufficient. And, we should return at this point, there's no reason to continue testing each date in the set.
Line 159: `!$date === '..'` will never be true. Put the negation outside the expression by using parentheses.

# What's new?

* Fixes edtf date set validation! Didn't work at all before.

# How should this be tested?

See additional notes.

# Additional Notes:
I have borrowed and am using the EDTFUtils class in my a custom Islandora 7 module and found these errors. I have not performed any testing in Islandora 8. Some sample edtf date-set strings to try:

`[2020-01-01,2020-01-02]` //pass
`[2020-01-01]` //pass 
`[]` //fail (no date)
`[2020-01-01, 2020-01-02]` //fail (spaces are not allowed)


# Interested parties
@Islandora/8-x-committers @seth-shaw-unlv 
