### PR TITLE
Add back in missing include for DateTime.

### DIFF
--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\controlled_access_terms;
 
-use DateTime;
-
 /**
  * Utility functions for working with Extended Date Time Format.
  */
@@ -277,8 +275,8 @@ class EDTFUtils {
           $parsed_date[self::DAY],
         ]);
       }
-      $datetime_obj = DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
-      $errors = DateTime::getLastErrors();
+      $datetime_obj = \DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
+      $errors = \DateTime::getLastErrors();
       if (!$datetime_obj ||
           !empty($errors['warning_count']) ||
           // DateTime will create valid dates from Y-m without warning,

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\controlled_access_terms;
 
+use DateTime;
+
 /**
  * Utility functions for working with Extended Date Time Format.
  */

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -269,11 +269,11 @@ class EDTFUtils {
         $cleaned_datetime = $datetime_str;
       }
       else {
-        $cleaned_datetime = implode('-', [
+        $cleaned_datetime = implode('-', array_filter([
           $parsed_date[self::YEAR_BASE],
           $parsed_date[self::MONTH],
           $parsed_date[self::DAY],
-        ]);
+        ]));
       }
       $datetime_obj = \DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
       $errors = \DateTime::getLastErrors();

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -282,7 +282,7 @@ class EDTFFormatter extends FormatterBase {
     }
 
     // Time.
-    // TODO: Add time formatting options.
+    // @todo Add time formatting options.
     if (array_key_exists(1, $date_time) && !empty($date_time[1])) {
       $formatted_date .= ' ' . $date_time[1];
     }


### PR DESCRIPTION
**GitHub Issue**: none

# What does this Pull Request do?

Add back in missing include that was probably mistakenly removed in https://github.com/Islandora/controlled_access_terms/commit/36d8674e115e87dd48c1b1d20cd46f36f4489bab

# How should this be tested?

If the include is missing, you should get the following error in your Apache `error.log`:

`Error: Class 'Drupal\\controlled_access_terms\\DateTime' not found in /var/www/html/drupal/web/modules/contrib/controlled_access_terms/src/EDTFUtils.php on line 278 #0 /var/www/html/drupal/web/modules/contrib/controlled_access_terms/src/EDTFUtils.php(159): Drupal\\controlled_access_terms\\EDTFUtils::validateDate('1996', '1')`

If the include is included, you will not get the error when adding a date.

# Interested parties
@seth-shaw-unlv 
