### PR TITLE
separated typed relation field into its own category

### DIFF
--- a/src/Plugin/Field/FieldType/TypedRelation.php
+++ b/src/Plugin/Field/FieldType/TypedRelation.php
@@ -14,6 +14,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "typed_relation",
  *   label = @Translation("Typed Relation"),
  *   module = "controlled_access_terms",
+ *   category = @Translation("Typed Relation"),
  *   description = @Translation("Implements a typed relation field"),
  *   default_formatter = "typed_relation_default",
  *   default_widget = "typed_relation_default",


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1715)


# What does this Pull Request do?

Separates the typed relation field into its own category

# What's new?
a doc comment change that separates the typed relation field into its own category so those fields are easier to distinguish from regular entity reference fields

# How should this be tested?

* Pull in the PR
* Cache clear
* Go to create a new field on an existing content type
* See typed relation fields separately
* Create a field just to be sure it still works

# Additional Notes:
Screenshot: 
<img width="325" alt="Screen Shot 2020-11-25 at 1 09 16 PM" src="https://user-images.githubusercontent.com/5439169/100277416-59623780-2f20-11eb-85ef-addfb7721af6.png">


# Interested parties
@Islandora/8-x-committers @antbrown
