### PR TITLE
add a formatter that dedupes based on tid

### DIFF
--- a/src/Plugin/Field/FieldFormatter/TypedRelationDedupFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationDedupFormatter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+
+/**
+ * Plugin implementation of the 'TypedRelationFormatter'.
+ *
+ * @FieldFormatter(
+ *   id = "typed_relation_dedup_default",
+ *   label = @Translation("Typed Relation Dedup Formatter"),
+ *   field_types = {
+ *     "typed_relation"
+ *   }
+ * )
+ */
+class TypedRelationDedupFormatter extends EntityReferenceLabelFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = parent::viewElements($items, $langcode);
+    $unique_tids = [];
+    foreach ($items as $delta => $item) {
+      $this_tid = $item->target_id;
+      $delta_to_update = in_array($this_tid, $unique_tids);
+      $rel_types = $item->getRelTypes();
+      $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
+      if (!$delta_to_update) {
+        $unique_tids[$delta] = $this_tid;
+        $elements[$delta]['#prefix'] = $rel_type . ': ';
+      }
+      else {
+        $delta_to_update = array_search($this_tid, $unique_tids);
+        $prefix_before = $elements[$delta_to_update]['#prefix'];
+        $prefix_parts = explode(": ", $prefix_before);
+        $elements[$delta_to_update]['#prefix'] = $prefix_parts[0] . ", " . $rel_type . ': ';
+        unset($elements[$delta]);
+      }
+
+    }
+
+    return $elements;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/TypedRelationDedupFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationDedupFormatter.php
@@ -9,7 +9,7 @@ use Drupal\Core\Field\FieldItemListInterface;
  * Plugin implementation of the 'TypedRelationFormatter'.
  *
  * @FieldFormatter(
- *   id = "typed_relation_dedup_default",
+ *   id = "typed_relation_dedup",
  *   label = @Translation("Typed Relation Dedup Formatter"),
  *   field_types = {
  *     "typed_relation"


### PR DESCRIPTION
*There was a slack conversation around when an agent played multiple roles with regards to a single item, that the agent would appear multiple times in the typed relation field, once per role. this is a display add on that de-duplicates based on the taxonomy term id.

# What does this Pull Request do?
Dedupes repeated agents for display

# What's new?
* a field formatter

# How should this be tested?
* create a node that has at least 2 agents. they should link to the same taxonomy term but with different roles.
* view the node and the default typed relation formatter should repeat the agents name twice (or however many times you repeated the agent), once per role.
* apply this PR
* clear your cache
* view the node again - you should now see the agent name deduplicated
like ```Animator (anm), Depositor (dpt): Sump-Crethar, Nicole```


# Interested parties
 @Islandora/8-x-committers @seth-shaw-unlv 
