### PR TITLE
Add formatter setting to suppress MARC Relator code in ()

### DIFF
--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
@@ -4,6 +4,7 @@ namespace Drupal\controlled_access_terms\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the 'TypedRelationFormatter'.
@@ -21,6 +22,38 @@ class TypedRelationFormatter extends EntityReferenceLabelFormatter {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings() {
+    return [
+        'suppress_code' => FALSE,
+      ] + parent::defaultSettings();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+
+    $elements = parent::settingsForm($form, $form_state);
+    $elements['suppress_code'] = [
+      '#title' => t('Hide code in () after label, if present'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->getSetting('suppress_code'),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $summary[] = $this->getSetting('suppress_code') ? t('Suppress code in (), if present') : t('Show code in (), if present');
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = parent::viewElements($items, $langcode);
 
@@ -28,9 +61,13 @@ class TypedRelationFormatter extends EntityReferenceLabelFormatter {
 
       $rel_types = $item->getRelTypes();
       $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
-      if (!empty($rel_type)) {
-        $elements[$delta]['#prefix'] = $rel_type . ': ';
+
+      // Suppress code, e.g. change Author (aut) to Author.
+      if ($this->getSetting('suppress_code') == TRUE) {
+        $rel_type = preg_replace('/ \([^()]*\)/', '', $rel_type);
       }
+
+      $elements[$delta]['#prefix'] = $rel_type . ': ';
     }
 
     return $elements;


### PR DESCRIPTION
**GitHub Issue**: No issue.

# What does this Pull Request do?

Changes Typed Relation Formatter to add display setting to suppress MARC Relator code. For example, changes "Author (aut): Bilbo Baggins" to "Author: Bilbo Baggins". Is hard-coded to look for `(` and `)` via regex.

# What's new?
Introduces new config field `suppress_code` for fields using "Typed Relation Formatter".

# How should this be tested?

* Apply patch
* Add Repository Item with Linked Agent values using MARC Relators.
* When viewing item, Linked Agent values should include MARC Relator codes in parentheses.
* Edit display for the relevant Repository Item display mode, e.g. PDFjs. Change Linked Agent field format to suppress code (checkbox "Hide code in () after label, if present" is checked). Save display configuration.
* Clear cache
* View repository item; Linked Agent values should no longer include MARC Relator codes in parentheses.

# Interested parties
@seth-shaw-unlv  @Islandora/8-x-committers
