### PR TITLE
Add initial EDTFYear processor

### DIFF
--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\controlled_access_terms\EDTFUtils;
+
+/**
+ * Adds the item's creation year to the indexed data.
+ *
+ * @SearchApiProcessor(
+ *   id = "edtf_year_only",
+ *   label = @Translation("EDTF Year"),
+ *   description = @Translation("Adds the item's EDTF date as a year."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class EDTFYear extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('EDTF Creation Date Year'),
+        'description' => $this->t('The year the item was created'),
+        'type' => 'integer',
+        'is_list' => TRUE,
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['edtf_year'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+
+    $node = $item->getOriginalObject()->getValue();
+
+    if ($node
+        && $node->hasField('field_edtf_date')
+        && !$node->field_edtf_date->isEmpty()) {
+      $edtf = $node->field_edtf_date->value;
+      if ($edtf != "nan" && empty(EDTFUtils::validate($edtf))) {
+        $years = [];
+        // Sets.
+        if (strpos($edtf, '[') !== FALSE || strpos($edtf, '{') !== FALSE) {
+          $years = preg_split('/(,|\.\.)/', trim($edtf, '{}[]'));
+        }
+        // Intervals.
+        elseif (strpos($edtf, '/') !== FALSE) {
+          $date_range = explode('/', $edtf);
+          if ($date_range[0] == '..') {
+            // The list of years needs to begin *somewhere*.
+            // This is hopefully a sensible default.
+            $begin = 0;
+          }
+          else {
+            $begin = $this->edtfToYearInt($date_range[0]);
+          }
+          if ($date_range[1] == '..') {
+            // Similarly, we need to end somewhere. Why not this year?
+            $end = intval(date("Y"));
+          }
+          else {
+            $end = $this->edtfToYearInt($date_range[1]);
+          }
+          $years = range($begin, $end);
+        }
+        else {
+          $years[] = $this->edtfToYearInt($edtf);
+        }
+        foreach ($years as $year) {
+          if (is_numeric($year)) {
+            $fields = $item->getFields(FALSE);
+            $fields = $this->getFieldsHelper()
+              ->filterForPropertyPath($fields, NULL, 'edtf_year');
+            foreach ($fields as $field) {
+              $field->addValue($year);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Convert a given EDTF date string into a year integer.
+   */
+  private function edtfToYearInt(string $edtf) {
+    $iso = EDTFUtils::iso8601Value($edtf);
+    $components = explode('-', $iso);
+    return intval(array_shift($components));
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: Partially addresses https://github.com/Islandora/documentation/issues/962

# What does this Pull Request do?

Builds on [ASU's IssueYear search_api plugin](https://github.com/asulibraries/islandora-repo/blob/develop/web/modules/custom/asu_search/src/Plugin/search_api/processor/IssueYear.php) to transform EDTF dates into Year integers suitable for searching and facets. This one also supports intervals and sets.

This one also allows sites to pick which EDTF fields they want to include and, for open intervals, the beginning and end years to use. (We currently need set year boundaries; we can't support truly open intervals, yet.)

# What's new?

* Added `src/Plugin/search_api/processor/EDTFYear.php`
* Does this change require documentation to be updated? Probably should document its existence and use...
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? If added to a search index config a site would have to re-index (as usual for adding search fields).

# How should this be tested?

* Apply the PR
* Go to the search_api_solr index processors config form (`/admin/config/search/search-api/index/default_solr_index/processors`)
    * Check the "EDTF Year" box.
    * Adjust the processor settings (down at the bottom) to select which fields you want to include. Optionally configure the open interval start and end year options.
    * Save the processors form
* Go to the search_api_solr index field config form (`/admin/config/search/search-api/index/default_solr_index/fields`)
    * Click "Add Field"
    * Find "EDTF Creation Date Year (edtf_year)" under "General Fields" and click "Add" in the modal window
    * Click "Done"
    * Save the form
* Create some items using the EDTF fields you selected. _Bonus: adjust the widget to permit intervals and sets and create records to test them, too._
* _You may need to manually tell the site to re-index depending on your settings._
* Query your SOLR instance to view all the edtf_year values OR create a facet using the new field and place the block on the search page to see it at work. _Note: ideally you could use the range facet widget, but I can't seem to get it to work. ☹️🤷‍♂️_

# Additional Notes

The facets range widget (the primary use-case for this processor) has a bug for D9 (https://www.drupal.org/project/facets/issues/3186953 and https://www.drupal.org/project/facets/issues/3153622) but @elizoller was able to get it working. It should be okay for D8 sites.

# Interested parties
@Islandora/8-x-committers, esp @elizoller
