### PR TITLE
Use JsonldNormalizerUtils in context to generate URI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
   "suggest": {
     "drupal/name": "Provides western-centric structured names."
   },
+  "conflict": {
+    "islandora/jsonld": "<2.1.0"
+  },
   "license": "GPL-2.0-or-later",
   "authors": [
     {

--- a/controlled_access_terms.module
+++ b/controlled_access_terms.module
@@ -56,7 +56,7 @@ function controlled_access_terms_jsonld_alter_normalized_array(EntityInterface $
             // We are assuming the first graph is the one corresponding
             // to the node/taxonomy_term we are modifying.
             $normalized['@graph'][0][$predicate][] = [
-              '@id' => $referenced_entity->toUrl('canonical', ['absolute' => TRUE])->setRouteParameter('_format', 'jsonld')->toString(),
+              '@id' => $context['utils']->getEntityUri($referenced_entity),
             ];
           }
         }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1766

# What does this Pull Request do?

Uses the new provided utility class to generate a URI for the JSON-LD that correctly does/does not add the `?_format=jsonld` suffix depending on the configuration.

# What's new?

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

Requires https://github.com/Islandora/jsonld/pull/58

With a normal Islandora setup:
1. Ensure that in Admin -> Configuration -> Search and metadata -> Jsonld, the `Remove jsonld parameter from @ids` is checked.
1. Add an item (with URI) to the Person taxonomy. 
1. Create a new Repository Item
1. Add the above Person in the "Linked Agent" field with some relationship.
1. Save the Repository Item.
1. View the JSON-LD for that node by adding `?_format=jsonld` to the URI. (ie. `http://localhost:8000/node/1?_format=jsonld`)
1. See that while most of the `@id` and `@type` elements DON'T have a `?_format=jsonld` suffix, the relation (depending on which you chose) DOES.
1. Pull in the associated JSON-LD PR and this PR.
1. Re-do the above steps and see that the relation URI in the JSON-LD will add or remove the `?_format=jsonld` based on the JSON-LD configuration.  

# Interested parties
@Islandora/8-x-committers @seth-shaw-unlv @mdlincoln @kspurgin 
