### PR TITLE
Add feeds target for edtf fields.

### DIFF
--- a/src/Feeds/Target/ExtendedDateTimeFormat.php
+++ b/src/Feeds/Target/ExtendedDateTimeFormat.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Feeds\Target;
+
+use Drupal\controlled_access_terms\EDTFUtils;
+use Drupal\feeds\Exception\TargetValidationException;
+use Drupal\feeds\Feeds\Target\StringTarget;
+
+
+/**
+ * Defines an edtf field mapper.
+ *
+ * @FeedsTarget(
+ *   id = "edtf_feeds_target",
+ *   field_types = {"edtf"}
+ * )
+ */
+
+class ExtendedDateTimeFormat extends StringTarget {
+  protected $settings;
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition) {
+    $this->targetDefinition = $configuration['target_definition'];
+    $this->settings = $this->targetDefinition->getFieldDefinition()->getSettings();
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function prepareValue($delta, array &$values) {
+    parent::prepareValue($delta, $values);
+    $errors = EDTFUtils::validate($values['value'], $this->settings['intervals'],$this->settings['sets'], $this->settings['strict_dates']);
+    if (!empty($errors)){
+      throw new TargetValidationException($this->t("Date given as [%date] not EDTF compliant.", ['%date' => $values['value']]));
+    }
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/islandora/documentation/issues/1976

# What does this Pull Request do?

Add a Feeds target for EDTF date fields

# What's new?

EDTF date target, which does validation.

# How should this be tested?

- composer require drupal/feeds
- set up a feed type to target a Repository Item content type.
- set up the feed with a mapping. Note you can set up mappings access many fields, but *not* the EDTF fields.
- install  this PR, clear cache, and you should be able to set up mappings to EDTF fields.
- import from the feeds with good and bad EDTF dates, and watch the bad dates get flagged (red errors show on screen) and the dates are not imported.

# Additional Notes:

I am baby dev. I'm not sure why but I couldn't access `$this->settings` unless i included the grandparent's `__construct` method. I am not sure if it's harmful but it's definitely not smooth.

# Interested parties
@seth-shaw-unlv @Islandora/8-x-committers 