### PR TITLE
Update EDTF Formatter with 'no value' options

### DIFF
--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -63,6 +63,7 @@ class EDTFFormatter extends FormatterBase {
         'space' => t("Space ' '"),
       ],
     ];
+
     $form['date_order'] = [
       '#title' => t('Date Order'),
       '#type' => 'select',
@@ -74,11 +75,13 @@ class EDTFFormatter extends FormatterBase {
         'middle_endian' => t('Middle-endian (month, day, year)'),
       ],
     ];
+
     $form['month_format'] = [
       '#title' => t('Month Format'),
       '#type' => 'select',
       '#default_value' => $this->getSetting('month_format'),
       '#options' => [
+        'nm' => t('Do not show Month'),
         'mm' => t('two-digit month, e.g. 04'),
         'm' => t('one-digit month for months below 10, e.g. 4'),
         'mmm' => t('three-letter abbreviation for month, Apr'),
@@ -90,8 +93,19 @@ class EDTFFormatter extends FormatterBase {
       '#type' => 'select',
       '#default_value' => $this->getSetting('day_format'),
       '#options' => [
+        'nd'  => t('Do not show day'),
         'dd' => t('two-digit day of the month, e.g. 02'),
         'd' => t('one-digit day of the month for days below 10, e.g. 2'),
+      ],
+    ];
+    $form['year_format'] = [
+      '#title' => t('Year Format'),
+      '#type' => 'select',
+      '#default_value' => $this->getSetting('year_format'),
+      '#options' => [
+        'ny'  => t('Do not show year'),
+        'yy' => t('two-digit day of the month, e.g. 02'),
+        'y' => t('four-digit representation of the year, e.g. 2020'),
       ],
     ];
     return $form;
@@ -242,6 +256,9 @@ class EDTFFormatter extends FormatterBase {
       elseif ($settings['month_format'] === 'm') {
         $month = ltrim($parsed_date[EDTFUtils::MONTH], ' 0');
       }
+      elseif ($settings['month_format'] == 'nm') {
+        $month = "";
+      }
       // IF 'mm', do nothing, it is already in this format.
       else {
         $month = $parsed_date[EDTFUtils::MONTH];
@@ -255,8 +272,21 @@ class EDTFFormatter extends FormatterBase {
       elseif ($settings['day_format'] === 'd') {
         $day = ltrim($parsed_date[EDTFUtils::DAY], ' 0');
       }
+      elseif ($settings['day_format'] == "nd") {
+        $day = "";
+      }
       else {
         $day = $parsed_date[EDTFUtils::DAY];
+      }
+    }
+
+    if (array_key_exists(EDTFUtils::YEAR_BASE, $parsed_date)) {
+      if ($settings['year_format'] == 'ny') {
+        $year = '';
+      } elseif ($settings['year_format'] = 'yy') {
+        $year = ltrim($parsed_date[EDTFUtils::YEAR_BASE], '0');
+      } else {
+        $year =  substr(ltrim($parsed_date[EDTFUtils::YEAR_BASE], '0'), 0, 2);
       }
     }
 
@@ -282,7 +312,7 @@ class EDTFFormatter extends FormatterBase {
     }
 
     // Time.
-    // @todo Add time formatting options.
+    // TODO: Add time formatting options.
     if (array_key_exists(1, $date_time) && !empty($date_time[1])) {
       $formatted_date .= ' ' . $date_time[1];
     }


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

Allow year and month to be hidden when displaying EDTF dates. Taken from [Born-Digital's updates to carapace](https://github.com/Islandora-Devops/islandora_install_profile_demo/blob/a8860b14a7dbfc66cb2545a79b08f9bce9a6da9a/modules/islandora_install_profile_demo_core/src/Plugin/Field/FieldFormatter/EDTFFormatter.php). They used it for [the newspaper view](https://github.com/Islandora-Devops/islandora_install_profile_demo/blob/a8860b14a7dbfc66cb2545a79b08f9bce9a6da9a/config/install/views.view.newspaper.yml); this PR pulls in these nice additions for those _not_ using carapace.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Added 'no value' options for month.
* Added year formatting options
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Apply the PR
* Use the EDTF date formatter settings to hide a month and/or year
* Ensure nothing blows up on us.

# Interested parties
@Islandora/8-x-committers and @noahwsmith