### PR TITLE
EDTF Formatter Year configuration fix (Issue 2016)

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Setup Mysql client
         run: |
           sudo apt-get update
+          sudo apt-get remove -y mysql-client mysql-common
           sudo apt-get install -y mysql-client
 
       - name: Set environment variables

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -305,9 +305,11 @@ class EDTFFormatter extends FormatterBase {
       $parts_in_order = [$year, $month, $day];
     }
 
+    # Special case for dates such as "Dec 29, 2021".
     if ($settings['date_order'] === 'middle_endian' &&
         !preg_match('/\d/', $month) &&
-        !empty(array_filter([$month, $day]))) {
+        self::DELIMITERS[$settings['date_separator']] == ' ' &&
+        count(array_filter([$year, $day])) == 2) {
       $formatted_date = "$month $day, $year";
     }
     else {

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -42,6 +42,7 @@ class EDTFFormatter extends FormatterBase {
     // ISO 8601 bias.
       'date_separator' => 'dash',
       'date_order' => 'big_endian',
+      'year_format' => 'y',
       'month_format' => 'mm',
       'day_format' => 'dd',
     ] + parent::defaultSettings();
@@ -104,7 +105,7 @@ class EDTFFormatter extends FormatterBase {
       '#default_value' => $this->getSetting('year_format'),
       '#options' => [
         'ny'  => t('Do not show year'),
-        'yy' => t('two-digit day of the month, e.g. 02'),
+        'yy' => t('two-digit representation of the year, e.g. 20'),
         'y' => t('four-digit representation of the year, e.g. 2020'),
       ],
     ];

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -305,7 +305,7 @@ class EDTFFormatter extends FormatterBase {
       $parts_in_order = [$year, $month, $day];
     }
 
-    # Special case for dates such as "Dec 29, 2021".
+    // Special case for dates such as "Dec 29, 2021".
     if ($settings['date_order'] === 'middle_endian' &&
         !preg_match('/\d/', $month) &&
         self::DELIMITERS[$settings['date_separator']] == ' ' &&


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2016

# What does this Pull Request do?

Allows persisting the year configuration for the EDTF formatter. Makes the middle-endian special condition case more stringent.

# What's new?

* Added default year_format.
* Fixed the copy/pasta the two-digit year option text.
* Added the mysql fix that has been killing builds lately.
* Makes the middle-endian case require day and year as well as the space separator.

# How should this be tested?

1. created a record with today's date using the date created field from islandora_defaults:
<img width="416" alt="Screen Shot 2021-12-21 at 11 49 51 AM" src="https://user-images.githubusercontent.com/29869988/146989989-23564dff-e321-4a89-8bd4-15c62d4e935b.png">

2. In the default islandora object display mode, the date created display settings inexplicitly says "Do not show year" even though it _did_:
<img width="971" alt="Screen Shot 2021-12-21 at 11 50 54 AM" src="https://user-images.githubusercontent.com/29869988/146990341-1c0cf071-4878-449d-9857-876ecd3ca9fa.png">

3. Also notice the two-digit year option copied the option text from month:
<img width="871" alt="Screen Shot 2021-12-21 at 11 52 05 AM" src="https://user-images.githubusercontent.com/29869988/146990428-173d5f02-e611-4dc9-af45-0c0563869ece.png">

4. Select the middle-endian option and select the option to not display the year, save the changes, and view the record noticing that the year _still_ displays: 
<img width="882" alt="Screen Shot 2021-12-21 at 11 53 57 AM" src="https://user-images.githubusercontent.com/29869988/146990800-9998bb1a-9207-49f8-98c4-6cbd0f68fe00.png">
<img width="426" alt="Screen Shot 2021-12-21 at 11 54 30 AM" src="https://user-images.githubusercontent.com/29869988/146990804-ae4ffdef-e747-4c24-9647-dab12349787a.png">

5. Apply the PR
6. Clear cache
7. Change the year settings to whatever you want and see their formatting correctly applied to your record.

# Additional Notes:
~~I haven't fixed the middle-endian issue yet, but I wanted to get this up in case I'm pulled away before leaving on vacation.~~

# Interested parties
@Islandora/8-x-committers
