### PR TITLE
Fix validate check

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -4,7 +4,7 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the 7.x branch
+  # Triggers the workflow on push or pull request events but only for the 2.x branch
   push:
     branches: [ 2.x ]
   pull_request:
@@ -63,6 +63,7 @@ jobs:
       - name: Setup Mysql client
         run: |
           sudo apt-get update
+          sudo apt-get remove -y mysql-client mysql-common
           sudo apt-get install -y mysql-client
 
       - name: Set environment variables

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -150,7 +150,7 @@ class EDTFUtils {
       }
     }
     // Intervals.
-    if ($intervals) {
+    if ($intervals && str_contains($edtf_text, '/')) {
       if (strpos($edtf_text, 'T') !== FALSE) {
         $msgs[] = "Date intervals cannot include times.";
       }

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -130,6 +130,9 @@ class EDTFUtils {
    *   Array of error messages. Valid if empty.
    */
   public static function validate($edtf_text, $intervals = TRUE, $sets = TRUE, $strict = FALSE) {
+    if (empty($edtf_text)) {
+      return ["Cannot parse empty value."];
+    }
     $msgs = [];
     // Sets.
     if ($sets) {

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -42,6 +42,7 @@ class EDTFFormatter extends FormatterBase {
     // ISO 8601 bias.
       'date_separator' => 'dash',
       'date_order' => 'big_endian',
+      'year_format' => 'y',
       'month_format' => 'mm',
       'day_format' => 'dd',
     ] + parent::defaultSettings();


### PR DESCRIPTION
Fixes validation in two small cases
Empty strings are now always prohibited and checking
for intervals does not error if a non-interval
value is given.

Previously:

```php
use Drupal\controlled_access_terms\EDTFUtils;
EDTFUtils::validate("", TRUE, TRUE, TRUE);
// yields [];
EDTFUtils::validate("", FALSE, TRUE, TRUE);
// yields [ "Could not parse the date ''." ]
EDTFUtils::validate("1985-04-12T23:20:30Z", TRUE, TRUE, TRUE);
// yields [ "Date intervals cannot include times." ]
```

Now:

```php
use Drupal\controlled_access_terms\EDTFUtils;
EDTFUtils::validate("", TRUE, TRUE, TRUE);
// yields [ "Cannot parse empty value." ];
EDTFUtils::validate("", FALSE, TRUE, TRUE);
// yields [ "Cannot parse empty value." ];
EDTFUtils::validate("1985-04-12T23:20:30Z", TRUE, TRUE, TRUE);
// yields [ ]
```
