### PR TITLE
EDTF validation constraint

### DIFF
--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -14,6 +14,9 @@ use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
  *   description = @Translation("Extended Date Time Format field"),
  *   default_formatter = "edtf_default",
  *   default_widget = "edtf_default",
+ *   constraints = {
+ *     "EDTF" = {},
+ *   },
  * )
  */
 class ExtendedDateTimeFormat extends StringItem {

--- a/src/Plugin/Validation/Constraint/EDTF.php
+++ b/src/Plugin/Validation/Constraint/EDTF.php
@@ -5,6 +5,8 @@ namespace Drupal\controlled_access_terms\Plugin\Validation\Constraint;
 use Symfony\Component\Validator\Constraint;
 
 /**
+ * EDTF constraint plugin.
+ *
  * @Constraint(
  *   id = "EDTF",
  *   label = @Translation("EDTF", context = "Validation"),
@@ -13,6 +15,11 @@ use Symfony\Component\Validator\Constraint;
  */
 class EDTF extends Constraint {
 
+  /**
+   * Invalid format message template.
+   *
+   * @var string
+   */
   public $invalid = '%value is not valid EDTF: %verbose';
 
 }

--- a/src/Plugin/Validation/Constraint/EDTF.php
+++ b/src/Plugin/Validation/Constraint/EDTF.php
@@ -13,6 +13,6 @@ use Symfony\Component\Validator\Constraint;
  */
 class EDTF extends Constraint {
 
-  public $invalidStuff = '%value is not valid EDTF.';
+  public $invalid = '%value is not valid EDTF: %verbose';
 
 }

--- a/src/Plugin/Validation/Constraint/EDTF.php
+++ b/src/Plugin/Validation/Constraint/EDTF.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Constraint(
+ *   id = "EDTF",
+ *   label = @Translation("EDTF", context = "Validation"),
+ *   type = "string",
+ * )
+ */
+class EDTF extends Constraint {
+
+  public $invalidStuff = '%value is not valid EDTF.';
+
+}

--- a/src/Plugin/Validation/Constraint/EDTFValidator.php
+++ b/src/Plugin/Validation/Constraint/EDTFValidator.php
@@ -18,7 +18,7 @@ class EDTFValidator extends ConstraintValidator {
    */
   public function validate($value, Constraint $constraint) {
     if (!$constraint instanceof EDTF) {
-      throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\\EDTF');
+      throw new UnexpectedTypeException($constraint, EDTF::class);
     }
     if (NULL === $value) {
       return;

--- a/src/Plugin/Validation/Constraint/EDTFValidator.php
+++ b/src/Plugin/Validation/Constraint/EDTFValidator.php
@@ -2,20 +2,37 @@
 
 namespace Drupal\controlled_access_terms\Plugin\Validation\Constraint;
 
+use Drupal\controlled_access_terms\EDTFUtils;
+
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
- * Validation.
+ * EDTF validation handler.
  */
 class EDTFValidator extends ConstraintValidator {
 
+  /**
+   * {@inheritdoc}
+   */
   public function validate($value, Constraint $constraint) {
-    $settings = $value->getFieldDefinition();
-    ddm($settings, 'qwer');
-    dsm($settings, 'asdf');
+    if (!$constraint instanceof EDTF) {
+      throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\\EDTF');
+    }
+    if (NULL === $value) {
+      return;
+    }
 
-    // TODO: The validation things, using the field's configuration.
+    foreach ($value->getValue() as $val) {
+      foreach (EDTFUtils::validate($val, TRUE, TRUE, FALSE) as $error) {
+        $this->context->buildViolation($constraint->invalid)
+          ->setParameter('%value', $val)
+          ->setParameter('%verbose', $error)
+          ->addViolation();
+      }
+    }
+
   }
 
 }

--- a/src/Plugin/Validation/Constraint/EDTFValidator.php
+++ b/src/Plugin/Validation/Constraint/EDTFValidator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validation.
+ */
+class EDTFValidator extends ConstraintValidator {
+
+  public function validate($value, Constraint $constraint) {
+    $settings = $value->getFieldDefinition();
+    ddm($settings, 'qwer');
+    dsm($settings, 'asdf');
+
+    // TODO: The validation things, using the field's configuration.
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1859

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Add a validation constraint to the EDTF field type, to ensure stored values pass basic validation.

# What's new?

The validation constraint for EDTF fields.

* Does this change require documentation to be updated? Unknown.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Potentially, if something is expecting to be able to write non-EDTF values to EDTF fields; however... this seems like it would be a bad idea to support?

# How should this be tested?

Could be done a couple of ways... with the code deployed:

1. Run a migration containing both valid and invalid EDTF values, with validation enabled, the valid things should work, and those invalid should fail; or,
2. Comment out the [validation from the widget](https://github.com/Islandora/controlled_access_terms/blob/68540956035db09909192da3afceeb3621407fef/src/Plugin/Field/FieldWidget/EDTFWidget.php#L120-L129), and attempt to save with various values both valid and invalid EDTF values.

# Additional Notes:

The settings from the widget are presently ignored by the constraint implementation, as there's not really a nice way to allow for later widening conversions of fields if desired... so the constraint allows both intervals and sets; however, it does _not_ perform the "strict" validation, due to other issues with it...

... ["strict" validation presently attempts to parse values into a `DateTime` object](https://github.com/Islandora/controlled_access_terms/blob/68540956035db09909192da3afceeb3621407fef/src/EDTFUtils.php#L269-L291), which will fail with valid EDTF values such as:

* `2021-21` (to mean "Spring, 2021")
    * Parsing into a `DateTime` fails, due to attempting to use the "21st" month     
* `19XX-12-31` (to mean "December 31st at some point in the 1900s", kind of thing)
    * "19XX" doesn't work as a year with `DateTime` 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
