### PR TITLE
Update testing, update drupals, add php 8's, use mysql 8.0

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    continue-on-error: true
+    fail-fast: false
     strategy:
       matrix:
         test-suite: ["kernel"]
@@ -28,7 +28,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }}
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
-      SCRIPT_DIR: $GITHUB_WORKSPACE/islandora_ci
+      SCRIPT_DIR: ${{ github.workspace }}/islandora_ci
       DRUPAL_DIR: /opt/drupal
       DRUPAL_EXTENSION_NAME: controlled_access_terms
 
@@ -100,7 +100,7 @@ jobs:
         run: |
           cd $DRUPAL_DIR/web
           drush --uri=127.0.0.1:8282 en -y controlled_access_terms
-        
+
       - name: Test scripts
         run: $SCRIPT_DIR/travis_scripts.sh
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         php-versions: ["7.4"]
         drupal-version: ["8.9.11", "9.1.5"]
+        test-suite: ["kernel"]
 
     services:
       mysql:
@@ -105,4 +106,4 @@ jobs:
       - name: PHP tests
         run: |
           cd $DRUPAL_DIR/web/core
-          php scripts/run-tests.sh --suppress-deprecations --url http://127.0.0.1:8282 --verbose --php `which php` --module "controlled_access_terms"
+          $DRUPAL_DIR/vendor/bin/phpunit --verbose --testsuite "${{ matrix.test-suite }}"

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -25,6 +25,12 @@ jobs:
         test-suite: ["kernel"]
         php-versions: ["7.4", "8.0", "8.1"]
         drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }}
+    env:
+      DRUPAL_VERSION: ${{ matrix.drupal-version }}
+      SCRIPT_DIR: $GITHUB_WORKSPACE/islandora_ci
+      DRUPAL_DIR: /opt/drupal
+      DRUPAL_EXTENSION_NAME: controlled_access_terms
 
     services:
       mysql:
@@ -68,12 +74,6 @@ jobs:
           sudo apt-get remove -y mysql-client mysql-common
           sudo apt-get install -y mysql-client
 
-      - name: Set environment variables
-        run: |
-          echo "DRUPAL_VERSION=${{ matrix.drupal-version }}" >> $GITHUB_ENV
-          echo "SCRIPT_DIR=$GITHUB_WORKSPACE/islandora_ci" >> $GITHUB_ENV
-          echo "DRUPAL_DIR=/opt/drupal" >> $GITHUB_ENV
-
       - name: Cache Composer dependencies
         uses: actions/cache@v2
         with:
@@ -100,11 +100,15 @@ jobs:
         run: |
           cd $DRUPAL_DIR/web
           drush --uri=127.0.0.1:8282 en -y controlled_access_terms
-
+        
       - name: Test scripts
         run: $SCRIPT_DIR/travis_scripts.sh
 
-      - name: PHP tests
+      - name: PHPUnit
+        working-directory: ${{ env.DRUPAL_DIR }}
+        env:
+          SIMPLETEST_BASE_URL: http://127.0.0.1:8282
+          SIMPLETEST_DB: mysql://drupal:drupal@127.0.0.1/drupal
+          BROWSERTEST_OUTPUT_DIRECTORY: /opt/drupal/web/sites/simpletest/browser_output
         run: |
-          cd $DRUPAL_DIR/web/core
-          $DRUPAL_DIR/vendor/bin/phpunit --verbose --testsuite "${{ matrix.test-suite }}"
+          $DRUPAL_DIR/vendor/bin/phpunit "--bootstrap=$DRUPAL_WEB_ROOT/core/tests/bootstrap.php" --group $DRUPAL_EXTENSION_NAME --verbose "$GITHUB_WORKSPACE"

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -30,6 +30,7 @@ jobs:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
       SCRIPT_DIR: ${{ github.workspace }}/islandora_ci
       DRUPAL_DIR: /opt/drupal
+      DRUPAL_WEB_ROOT: /opt/drupal/web
       DRUPAL_EXTENSION_NAME: controlled_access_terms
 
     services:

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,8 +19,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    fail-fast: false
     strategy:
+      fail-fast: false
       matrix:
         test-suite: ["kernel"]
         php-versions: ["7.4", "8.0", "8.1"]

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,14 +19,15 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
-        php-versions: ["7.4"]
-        drupal-version: ["8.9.11", "9.1.5"]
+        php-versions: ["7.4", "8.0", "8.1"]
+        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: drupal

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "drupal/name": "Provides western-centric structured names."
   },
   "conflict": {
-    "islandora/jsonld": "<2.1.0"
+    "islandora/jsonld": "<2.1.0",
+    "drupal/core": "<=8"
   },
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/controlled_access_terms.info.yml
+++ b/controlled_access_terms.info.yml
@@ -1,8 +1,7 @@
 name: 'Controlled Access Terms'
 type: module
 description: 'Provides topic, geographic, person, family, and corporate body entites as well as an authorities link field.'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9
 package: 'Controlled Access Terms'
 
 dependencies:


### PR DESCRIPTION
Related PR: https://github.com/Islandora/islandora/pull/886

# What does this Pull Request do?

Update the testing matrix to use newer versions.

# What's new?

* add php 8.0 and 8.1. They both pass so far.
* Deprecate testing on Drupal 8, and deprecate D8.
* sets environment variables in a nicer way
* use the new unit test calling methodology (introduced between Drupal 9.1 and 9.4.)

# How should this be tested?

Tests pass

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers 