### PR TITLE
More schema definition fun.

### DIFF
--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -36,6 +36,13 @@ field.widget.settings.text_edtf:
       type: boolean
       label: 'Intervals Permitted'
 
+field.widget.settings.edtf_default:
+  type: field.widget.settings.text_edtf
+  mapping:
+    sets:
+      type: boolean
+      label: Sets permitted
+
 field.widget.settings.text_date:
   type: mapping
   link: ''
@@ -83,9 +90,15 @@ field.formatter.settings.text_edtf_human:
     day_format:
       type: string
       label: 'Day Format'
+    year_format:
+      type: string
+      label: 'Year Format'
     season_hemisphere:
       type: string
       label: 'Hemisphere Seasons'
+
+field.formatter.settings.edtf_default:
+  type: field.formatter.settings.text_edtf_human
 
 field.formatter.settings.text_edtf_iso8601:
   type: mapping
@@ -94,3 +107,35 @@ field.formatter.settings.text_edtf_iso8601:
     season_hemisphere:
       type: string
       label: 'Hemisphere Seasons'
+
+field.field_settings.typed_relation:
+  type: field.field_settings.entity_reference
+  mapping:
+    rel_types:
+      type: sequence
+      sequence:
+        type: string
+
+field.storage_settings.edtf:
+  type: field.storage_settings.string
+
+field.widget.settings.typed_relation_default:
+  type: mapping
+  mapping:
+    match_operator:
+      type: string
+    size:
+      type: integer
+    placeholder:
+      type: string
+    match_limit:
+      type: integer
+
+field.formatter.settings.typed_relation_default:
+  type: mapping
+  mapping:
+    link:
+      type: boolean
+
+field.storage_settings.typed_relation:
+  type: field.storage_settings.entity_reference


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2164

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Fleshes out config schema.

# What's new?

A number of new config schemas being defined. Later exports may end up changing the types of values stored in exported YAML; for example: If something is now defined as a `boolean`, it should now be exported as a `true` or `false` whereas before it would've likely been the integers `1` or `0`... shouldn't really have any effect, just might cause a bit of noise in diffs as it happens.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unlikely.

# How should this be tested?

1. Install and enable the `config_inspector` module
2. Either:
    1. Run:
        ```
        drush config:inspect --only-error --detail
        ```
        or:
     2. Looks at the reports at `/admin/reports/config-inspector`

    to note the number of config errors present from the plugins defined in Islandora.
3. Grab the code
4. Clear cache
5. Re-run/Look at the config_inspector output, and see that the number of errors should be reduced. 

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
