### PR TITLE
wrap the relator type with t() function

### DIFF
--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -114,7 +114,7 @@ field.field_settings.typed_relation:
     rel_types:
       type: sequence
       sequence:
-        type: string
+        type: label
 
 field.storage_settings.edtf:
   type: field.storage_settings.string

--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
@@ -29,7 +29,7 @@ class TypedRelationFormatter extends EntityReferenceLabelFormatter {
       $rel_types = $item->getRelTypes();
       $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
       if (!empty($rel_type)) {
-        $elements[$delta]['#prefix'] = $rel_type . ': ';
+        $elements[$delta]['#prefix'] = $this->t($rel_type) . ': ';
       }
     }
 

--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
@@ -29,7 +29,7 @@ class TypedRelationFormatter extends EntityReferenceLabelFormatter {
       $rel_types = $item->getRelTypes();
       $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
       if (!empty($rel_type)) {
-        $elements[$delta]['#prefix'] = $this->t($rel_type) . ': ';
+        $elements[$delta]['#prefix'] = $rel_type . ': ';
       }
     }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/controlled_access_terms/issues/90

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.) - internal issue with one of our client's sites

# What does this Pull Request do?
It wraps the relator type in the t() function.

This allows the agent relator type and the three digit code to be translated via the User Interface translation configurations.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Does this change require documentation to be updated? I really do not think so -- this likely is providing expected functionality.
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?
1. Pull this branch of controlled_access_terms into any working islandora site 
2. Configure that site for multiple languages.
3. Add or edit any Islandora object to have at least one Linked Agent field.
4. Provide a translation value for that relator type and three digit code, for example "Author (aut)" to French would be "Auteur (aut)". NOTE: attempting to provide a translation ONLY for the relator type without the three digit code does not seem to work.
5. Select the secondary language to view that item and see that it is translated as configured.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable) -- simply view any Islandora Object that has a linked agent in a secondary language -- and attempt to provide a User Interface translation for the relator name at /admin/config/regional/translate. 
