### PR TITLE
Switch to use schema to define rel_type as translatable.

### DIFF
--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -114,7 +114,7 @@ field.field_settings.typed_relation:
     rel_types:
       type: sequence
       sequence:
-        type: string
+        type: label
 
 field.storage_settings.edtf:
   type: field.storage_settings.string

--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatter.php
@@ -29,7 +29,7 @@ class TypedRelationFormatter extends EntityReferenceLabelFormatter {
       $rel_types = $item->getRelTypes();
       $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
       if (!empty($rel_type)) {
-        $elements[$delta]['#prefix'] = $this->t($rel_type) . ': ';
+        $elements[$delta]['#prefix'] = $rel_type . ': ';
       }
     }
 


### PR DESCRIPTION
It works!

Before this change:

<img width="1120" alt="Translation form for the linked agent field with fields for label and help text." src="https://user-images.githubusercontent.com/1943338/213304468-72fe6660-352d-4c04-a2f7-6b27150ac1be.png">

After this change and a `drush cr`:
<img width="1091" alt="Translation form for the linked agent field with more fields including 'Abridger'" src="https://user-images.githubusercontent.com/1943338/213304713-1dbb83f6-2a22-4da0-9886-31059b0635d2.png">
