### PR TITLE
fix/add tests for validation and ISO 8601

### DIFF
--- a/src/EDTFConverter.php
+++ b/src/EDTFConverter.php
@@ -30,7 +30,7 @@ class EDTFConverter extends CommonDataConverter {
   }
 
   /**
-   * Converts an EDTF text field into an ISO 8601 timestamp string.
+   * Converts an EDTF text field into an ISO 8601 date.
    *
    * It assumes the earliest valid date for approximations and intervals.
    *

--- a/tests/src/Kernel/EdtfUtilsTest.php
+++ b/tests/src/Kernel/EdtfUtilsTest.php
@@ -19,7 +19,7 @@ class EdtfUtilsTest extends KernelTestBase {
    *
    * @var array
    */
-  private $testCases = [
+  private $singleDateValidations = [
     '1900' => [],
     '1900-01' => [],
     '1900-01-02' => [],
@@ -27,17 +27,18 @@ class EdtfUtilsTest extends KernelTestBase {
     '1900-XX' => [],
     '1900-91' => ['Provided month value \'91\' is not valid.'],
     '1900-91-01' => ['Provided month value \'91\' is not valid.'],
+    '1900-X1' => ['Provided month value \'X1\' is not valid.'],
     // No validation for months with X.
-    '1900-3X' => [],
+    '1900-3X' => ['Provided month value \'3X\' is not valid.'],
     // Month 31 without a day matches summer so it's valid.
     '1900-31' => [],
     '1900-31-01' => ['Provided month value \'31\' is not valid.'],
-    '190X-5X-8X' => [],
+    '190X-5X-8X' => ['Provided month value \'5X\' is not valid.'],
     '19000' => ['Years longer than 4 digits must be prefixed with a \'Y\'.'],
     'Y19000' => [],
     '190u' => ['Could not parse the date \'190u\'.'],
-    '190' => ['Years must be at least 4 characters long.'],
-    '190-99-52' => ['Years must be at least 4 characters long.',
+    '190' => [],
+    '190-99-52' => [
       'Provided month value \'99\' is not valid.',
       'Provided day value \'52\' is not valid.',
     ],
@@ -53,8 +54,46 @@ class EdtfUtilsTest extends KernelTestBase {
    * @covers ::validate
    */
   public function testEdtfValidate() {
-    foreach ($this->testCases as $input => $expected) {
+    foreach ($this->singleDateValidations as $input => $expected) {
       $this->assertEquals($expected, EDTFUtils::validate($input, FALSE, FALSE, FALSE));
+    }
+  }
+
+  /**
+   * @covers ::iso8601Value
+   */
+  public function testIso8601() {
+    // EDTF value and ISO 8601 Timestamp results.
+    // Empty values are invalid dates which return blank.
+    $tests = [
+      '1900' => '1900',
+      '1900-01' => '1900-01',
+      '1900-01-02' => '1900-01-02',
+      '190X' => '1900',
+      '1900-XX' => '1900-01',
+      '1900-91' => '',
+      '1900-91-01' => '',
+      '1900-3X' => '',
+      '1900-31' => '1900-03',
+      '190X-5X-8X' => '',
+      '19000' => '',
+      'Y19000' => '19000',
+      '190u' => '',
+      '190' => '190',
+      '190-99-52' => '',
+      '1900-01-02T' => '',
+      '1900-01-02T1:1:1' => '',
+      '1900-01-02T01:22:33' => '1900-01-02T01:22:33',
+      '1900-01-02T01:22:33Z' => '1900-01-02T01:22:33Z',
+      '1900-01-02T01:22:33+' => '',
+      '1900-01-02T01:22:33+05:00' => '1900-01-02T01:22:33+05:00',
+      // Intervals and Sets should return the earliest value.
+      '1900/2023' => '1900',
+      '[1900,2023]' => '1900',
+      '[1900,2023}' => '1900',
+    ];
+    foreach ($tests as $date => $iso) {
+      $this->assertEquals($iso, EDTFUtils::iso8601Value($date));
     }
   }
 


### PR DESCRIPTION
**GitHub Issue**: #103 

# What does this Pull Request do?

Addresses issue with date intervals throwing a warning when passed to `EDTF:Utils::iso8601Value`. Also updates and adds more tests.

* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

Short version: tests pass. :+1: 

Longer version:

* Spin up a site with controlled_access_terms.
* using the command-line: `drush ev 'print(\Drupal\controlled_access_terms\EDTFUtils::iso8601Value("2023-07/2023-08")."\n");'`
* Observe the warning.
* Apply PR
* Run the command again and no warning appears.

# Additional Notes
An early version of this was accidentally pushed directly to the repo which I then reverted. This PR is the real version.

# Interested parties
@Islandora/committers
