### PR TITLE
Add 3.x for professional-wiki/edtf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "drupal/geolocation": "^3.2",
     "drupal/token": "^1.7",
-    "professional-wiki/edtf": "^2.0"
+    "professional-wiki/edtf": "^2 || ^3"
   },
   "require-dev": {
     "phpunit/phpunit": "^6",


### PR DESCRIPTION
**GitHub Issue**: #101

# What does this Pull Request do?

Adds `^3` as a valid version for professional-wiki/edtf.

# How should this be tested?

* `composer require islandora/controlled_access_terms:"dev-issue-101 as 2.2.3" professional-wiki/edtf:^3`. Composer should be happy with this.
* Smoke test, especially the year indexing feature, which is the only spot where we currently use the professional-wiki code.

Alternatively, if you don't want to go through and set up all the year search index stuff, you could save the [test-edtf-3.php.txt](https://github.com/Islandora/controlled_access_terms/files/12255644/test-edtf-3.php.txt) (a trimmed down version of the year index code) to your web directory, rename it to remove '.txt' which I had to add to appease GitHub, and run `drush scr test-edtf-3.php -- '2017/2022'` (or substitute '2017/2022' with any other valid EDTF). Look for a list of integers matching the years covered by the EDTF with no errors appearing.

# Interested parties
@Islandora/committers
