### PR TITLE
Update PHP and Drupal versions in testing matrix.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         test-suite: ["kernel"]
-        php-versions: ["7.4", "8.0", "8.1"]
-        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
+        php-versions: ["8.1", "8.2"]
+        drupal-version: ["10.0.x", "10.1.x", "10.2.x-dev"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }}
     env:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2262

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
Discussed at Committers Call Oct 18, 2023

# What does this Pull Request do?

Adds PHP 8.2 and Drupal 10.2 to the testing matrix. Removes Drupal 9.5 (6 days till EOL).

# How should this be tested?

Check the tests! Likely they will fail, and/or reveal some deprecations and other things we need to take care of. This should probably be merged anyway and the tests dealt with separately.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
