### PR TITLE
Index date intervals that use null as one of the ends.

### DIFF
--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -182,7 +182,7 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                 }
                 else {
                   $end_year = (empty($this->configuration['open_end_year'])) ? date('Y') : $this->configuration['open_end_year'];
-                  $edtf = str_replace('/..', '/' . $this->configuration['open_end_year'], $edtf);
+                  $edtf = str_replace('/..', '/' . $end_year, $edtf);
                 }
               }
               // Open end dates with `/`.
@@ -192,7 +192,7 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                 }
                 else {
                   $end_year = (empty($this->configuration['open_end_year'])) ? date('Y') : $this->configuration['open_end_year'];
-                  $edtf = str_replace('/', '/' . $this->configuration['open_end_year'], $edtf);
+                  $edtf = str_replace('/', '/' . $end_year, $edtf);
                 }
               }
               $parsed = $parser->parse($edtf)->getEdtfValue();

--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -157,7 +157,7 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
               }, $dates->getDates());
             }
             else {
-              // Open start dates.
+              // Open start dates with `../`.
               if (substr($edtf, 0, 3) === '../') {
                 if ($this->configuration['ignore_open_start']) {
                   $edtf = substr($edtf, 3);
@@ -166,7 +166,16 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                   $edtf = str_replace('../', $this->configuration['open_start_year'] . '/', $edtf);
                 }
               }
-              // Open end dates.
+              // Open start dates with `/`.
+              if (substr($edtf, 0, 1) === '/') {
+                if ($this->configuration['ignore_open_start']) {
+                  $edtf = substr($edtf, 1);
+                }
+                else {
+                  $edtf = str_replace('/', $this->configuration['open_start_year'] . '/', $edtf);
+                }
+              }
+              // Open end dates with `/..`.
               if (substr($edtf, -3) === '/..') {
                 if ($this->configuration['ignore_open_end']) {
                   $edtf = substr($edtf, 0, -3);
@@ -176,7 +185,16 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                   $edtf = str_replace('/..', '/' . $this->configuration['open_end_year'], $edtf);
                 }
               }
-
+              // Open end dates with `/`.
+              if (substr($edtf, -1) === '/') {
+                if ($this->configuration['ignore_open_end']) {
+                  $edtf = substr($edtf, 0, -1);
+                }
+                else {
+                  $end_year = (empty($this->configuration['open_end_year'])) ? date('Y') : $this->configuration['open_end_year'];
+                  $edtf = str_replace('/', '/' . $this->configuration['open_end_year'], $edtf);
+                }
+              }
               $parsed = $parser->parse($edtf)->getEdtfValue();
               $years = range(intval(date('Y', $parsed->getMin())), intval(date('Y', $parsed->getMax())));
             }


### PR DESCRIPTION
**GitHub Issue**: #109 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Indexes EDTF years for dates formatted as intervals where one end (start or end) is just null, e.g. `2020/` or `/1999`. 

Removes error messages "Could not parse EDTF value 2020/ for node/nid".

# What's new?

* Looks for `/` as well as `../` as signifier of an empty start of interval, and `/` as well as `/..` at the end of an interval.
* Also switches to use the calculated `$end_year` being the current year or the configured "end date value" in the EDTF Year processor. It looks like this was created but never implemented.


* Does this change require documentation to be updated?  no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  You may want to re-index your content if you have nulls in your intervals.
* Could this change impact execution of existing code? no
 
# How should this be tested?

Recreate issue #109
* Alter the form for repository item so that Date Issued allows intervals.
* In a node, enter in Date Issued an interval with a null start or end date e.g. `1999/`
* Save the node.
* Go to the watchdog logs, see that error message "Could not parse EDTF value 1999/ for node/nid".
* Search content for your node, and see that the "Year" facet does not get populated with the years between 1999 and now (or up to whatever you have configured in the EDTF Year Search API Processor)
* If you want, go to Solr and see that its `itm_edtf_year` field is empty.

With this PR:
* Edit the date to a different date range and save the node.
* You should not see an error in watchdog.
* You can go to a search page and see all the relevant years in the "Year" facet.
* If you go to Solr, `itm_edtf_year` holds all the configured values.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag @seth-shaw-asu 
