### PR TITLE
DGI9-314: Allow date fields from paragraphs

### DIFF
--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\controlled_access_terms\Plugin\search_api\processor;
 
+use Drupal\controlled_access_terms\EDTFUtils;
 use Drupal\Core\Entity\EntityInterface;
-use EDTF\EdtfFactory;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\search_api\Datasource\DatasourceInterface;
@@ -11,7 +11,7 @@ use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
-use Drupal\controlled_access_terms\EDTFUtils;
+use EDTF\EdtfFactory;
 
 /**
  * Adds the item's creation year to the indexed data.
@@ -142,7 +142,7 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
       [$entityType, $bundle, $field_name] = explode('|', $field, 3);
 
       if ($entityType === 'paragraph') {
-       $edtf = $this->getDateFromParagraphField($entity, $bundle, $field_name);
+        $edtf = $this->getDateFromParagraphField($entity, $bundle, $field_name);
       }
       elseif ($entity->getEntityTypeId() == $entityType
         && $entity->bundle() == $bundle
@@ -200,7 +200,8 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                 }
               }
             }
-          } catch (\Throwable $e) {
+          }
+          catch (\Throwable $e) {
             \Drupal::logger('controlled_access_terms')
               ->warning(t("Could not parse EDTF value '@edtf' for indexing @type/@id",
                 [

--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\controlled_access_terms\Plugin\search_api\processor;
 
+use Drupal\Core\Entity\EntityInterface;
 use EDTF\EdtfFactory;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
@@ -67,10 +68,13 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $formState) {
     $form['#description'] = $this->t('Select the fields containing EDTF strings to extract year values for.');
-    $fields = \Drupal::entityTypeManager()->getStorage('field_config')->loadByProperties(['field_type' => 'edtf']);
+    $fields = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->loadByProperties(['field_type' => 'edtf']);
     $fields_options = [];
     foreach ($fields as $field) {
-      $fields_options[$field->getTargetBundle() . '|' . $field->get('field_name')] = $this->t("%label (%bundle)", [
+      $fields_options[$field->getTargetEntityTypeId() . '|' . $field->getTargetBundle() . '|' . $field->get('field_name')] = $this->t("%label (%type:%bundle)", [
+        '%type' => $field->getTargetEntityTypeId(),
         '%label' => $field->label(),
         '%bundle' => $field->getTargetBundle(),
       ]);
@@ -133,15 +137,21 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
    * {@inheritdoc}
    */
   public function addFieldValues(ItemInterface $item) {
-
     $entity = $item->getOriginalObject()->getValue();
     foreach ($this->configuration['fields'] as $field) {
-      list($bundle, $field_name) = explode('|', $field, 2);
-      if ($entity
-          && $entity->bundle() == $bundle
+      [$entityType, $bundle, $field_name] = explode('|', $field, 3);
+
+      if ($entityType === 'paragraph') {
+       $edtf = $this->getDateFromParagraphField($entity, $bundle, $field_name);
+      }
+      elseif ($entity->getEntityTypeId() == $entityType
+        && $entity->bundle() == $bundle
         && $entity->hasField($field_name)
         && !$entity->get($field_name)->isEmpty()) {
         $edtf = trim($entity->get($field_name)->value);
+      }
+
+      if ($edtf) {
         if ($edtf != "nan" && empty(EDTFUtils::validate($edtf))) {
           if ($this->configuration['ignore_undated'] && $edtf == "XXXX") {
             continue;
@@ -190,16 +200,40 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
                 }
               }
             }
-          }
-          catch (\Throwable $e) {
-            \Drupal::logger('controlled_access_terms')->warning(t("Could not parse EDTF value '@edtf' for indexing @type/@id",
-            [
-              '@edtf' => $edtf,
-              '@type' => $entity->getEntityTypeId(),
-              '@id' => $entity->id(),
-            ]));
+          } catch (\Throwable $e) {
+            \Drupal::logger('controlled_access_terms')
+              ->warning(t("Could not parse EDTF value '@edtf' for indexing @type/@id",
+                [
+                  '@edtf' => $edtf,
+                  '@type' => $entity->getEntityTypeId(),
+                  '@id' => $entity->id(),
+                ]));
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Gets edtf date value from a referenced paragraph.
+   */
+  private function getDateFromParagraphField(EntityInterface $entity, string $bundle, string $field_name) {
+    $query = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->getQuery();
+    $query->condition('bundle', $entity->bundle());
+    $query->condition("settings.handler_settings.target_bundles.{$bundle}", $bundle);
+    $paragraph_ids = $query->execute();
+    if (!empty($paragraph_ids)) {
+      $paragraph_field_config = reset($paragraph_ids);
+      $paragraph_field_config_array = explode('.', $paragraph_field_config);
+      $paragraph_field_name = end($paragraph_field_config_array);
+      $paragraph_entity = $entity->get($paragraph_field_name)
+        ->referencedEntities()[0] ?? NULL;
+
+      if ($paragraph_entity->hasField($field_name)
+        && !$paragraph_entity->get($field_name)->isEmpty()) {
+        return trim($paragraph_entity->get($field_name)->value);
       }
     }
   }


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora/controlled_access_terms/issues/112)

# What does this Pull Request do?

Allows parsing of paragraph fields in date edtf processor.

# What's new?
* New method added to get dates from paragraph fields.
* EDTF Year field config saves entity type as an extra option.

# How should this be tested?

Create a paragraph with EDTF date field. 
Reference this paragraph inside a node. 
In Search API processor settings, enable EDTF Year and select the paragraph date field. 
Reindex.


# Interested parties
@Islandora/committers
