### PR TITLE
Fix PHP warnings when indexing in solr

### DIFF
--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -139,8 +139,14 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
   public function addFieldValues(ItemInterface $item) {
     $entity = $item->getOriginalObject()->getValue();
     foreach ($this->configuration['fields'] as $field) {
-      [$entityType, $bundle, $field_name] = explode('|', $field, 3);
+      $components = explode('|', $field, 3);
+      if (count($components) != 3) {
+        continue;
+      }
 
+      [$entityType, $bundle, $field_name] = $components;
+
+      $edtf = FALSE;
       if ($entityType === 'paragraph') {
         $edtf = $this->getDateFromParagraphField($entity, $bundle, $field_name);
       }


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Continues iterating over the loop if an EDTF value isn't defined

Was getting these warnings in my watchdog when indexing nodes in solr:

```
Warning: Undefined array key 2 in Drupal\controlled_access_terms\Plugin\search_api\processor\EDTFYear->addFieldValues() (line 142 of /var/www/drupal/web/modules/contrib/controlled_access_terms/src/Plugin/search_api/processor/EDTFYear.php)
#0 /var/www/drupal/web/core/includes/bootstrap.inc(164): _drupal_error_handler_real()
#1 /var/www/drupal/web/modules/contrib/controlled_access_terms/src/Plugin/search_api/processor/EDTFYear.php(142): _drupal_error_handler()
```

```
Warning: Undefined variable $edtf in Drupal\controlled_access_terms\Plugin\search_api\processor\EDTFYear->addFieldValues() (line 154 of /var/www/drupal/web/modules/contrib/controlled_access_terms/src/Plugin/search_api/processor/EDTFYear.php)
#0 /var/www/drupal/web/core/includes/bootstrap.inc(164): _drupal_error_handler_real()
#1 /var/www/drupal/web/modules/contrib/controlled_access_terms/src/Plugin/search_api/processor/EDTFYear.php(154): _drupal_error_handler()
```

# What's new?

Just declaring some variables that cause warning if the assumptions in the code aren't met.

# How should this be tested?

I tested by just making the code changes and seeing the watchdog messages go away.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers
