### PR TITLE
Validate date intervals  - start date must be before end date

### DIFF
--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -165,7 +165,7 @@ class EDTFUtils {
         if (!empty($dates[1]) && !($dates[1] == '..')) {
           $msgs = array_merge($msgs, self::validateDate($dates[1], $strict));
         }
-        // Check if start date is sooner than end date
+        // Check if start date is sooner than end date.
         if (self::compareDates($dates[0], $dates[1]) > 0) {
           $msgs[] = "The start date must be sooner than the end date.";
         }
@@ -188,7 +188,7 @@ class EDTFUtils {
    *   The second date.
    *
    * @return int
-   *   Returns -1 if $date1 is earlier, 1 if $date1 is later, 0 if they are equal.
+   *   Returns -1, 1 or 0 based on the order of the two dates.
    */
   private static function compareDates($date1, $date2) {
     $isoDate1 = self::iso8601Value($date1);

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -157,15 +157,50 @@ class EDTFUtils {
       if (strpos($edtf_text, 'T') !== FALSE) {
         $msgs[] = "Date intervals cannot include times.";
       }
-      foreach (explode('/', $edtf_text) as $date) {
-        if (!empty($date) && !($date == '..')) {
-          $msgs = array_merge($msgs, self::validateDate($date, $strict));
+      $dates = explode('/', $edtf_text);
+      if (count($dates) == 2) {
+        if (!empty($dates[0]) && !($dates[0] == '..')) {
+          $msgs = array_merge($msgs, self::validateDate($dates[0], $strict));
         }
+        if (!empty($dates[1]) && !($dates[1] == '..')) {
+          $msgs = array_merge($msgs, self::validateDate($dates[1], $strict));
+        }
+        // Check if start date is sooner than end date
+        if (self::compareDates($dates[0], $dates[1]) > 0) {
+          $msgs[] = "The start date must be sooner than the end date.";
+        }
+      }
+      else {
+        $msgs[] = "Invalid interval format.";
       }
       return $msgs;
     }
     // Single date (we assume at this point).
     return self::validateDate($edtf_text, $strict);
+  }
+
+  /**
+   * Compare two EDTF dates.
+   *
+   * @param string $date1
+   *   The first date.
+   * @param string $date2
+   *   The second date.
+   *
+   * @return int
+   *   Returns -1 if $date1 is earlier, 1 if $date1 is later, 0 if they are equal.
+   */
+  private static function compareDates($date1, $date2) {
+    $isoDate1 = self::iso8601Value($date1);
+    $isoDate2 = self::iso8601Value($date2);
+
+    if ($isoDate1 < $isoDate2) {
+      return -1;
+    }
+    elseif ($isoDate1 > $isoDate2) {
+      return 1;
+    }
+    return 0;
   }
 
   /**

--- a/tests/src/Kernel/EdtfUtilsTest.php
+++ b/tests/src/Kernel/EdtfUtilsTest.php
@@ -49,6 +49,7 @@ class EdtfUtilsTest extends KernelTestBase {
     '1900-01-02T01:22:33Z' => [],
     '1900-01-02T01:22:33+' => ['The date/time \'1900-01-02T01:22:33+\' is invalid.'],
     '1900-01-02T01:22:33+05:00' => [],
+    '2025-01-01/2000-01-01' => ['The start date must be sooner than the end date.'],
   ];
 
   /**


### PR DESCRIPTION
**GitHub Issue**:
#123 

# What does this Pull Request do?

Adds stricter validation for date ranges, start date should be earlier than end date.

# What's new?

It validates date intervals for EDTF fields, so previously accepted (but incorrect) date entries could become suddenly not accepted by this change.

# Interested parties
@Islandora/committers
