### PR TITLE
Adding a null check for the $paragraph_entity

### DIFF
--- a/src/Plugin/search_api/processor/EDTFYear.php
+++ b/src/Plugin/search_api/processor/EDTFYear.php
@@ -251,7 +251,7 @@ class EDTFYear extends ProcessorPluginBase implements PluginFormInterface {
       $paragraph_entity = $entity->get($paragraph_field_name)
         ->referencedEntities()[0] ?? NULL;
 
-      if ($paragraph_entity->hasField($field_name)
+      if ($paragraph_entity && $paragraph_entity->hasField($field_name)
         && !$paragraph_entity->get($field_name)->isEmpty()) {
         return trim($paragraph_entity->get($field_name)->value);
       }


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

The $paragraph_entity variable could be set as null and then immediately have a member function attempt to be called on it, resulting in the following error:
```
Fatal error: Uncaught Error: Call to a member function hasField() on null in /path/to/files/controlled_access_terms/src/Plugin/search_api/processor/EDTFYear.php:254
```

# What's new?
Adding a null check for the $paragraph_entity.

* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No.
* Could this change impact execution of existing code? Yes.

# How should this be tested?

Enabling the EDTF Year processor and indexing the edtf_year field.

# Interested parties
@Islandora/committers