### PR TITLE
Use drupal namespace instead of islandora.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -95,7 +95,7 @@ jobs:
           cd $DRUPAL_DIR
           composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
           composer config minimum-stability dev
-          composer require "islandora/controlled_access_terms:dev-github-testing as dev-2.x"
+          composer require "drupal/controlled_access_terms:dev-github-testing as dev-2.x"
 
       - name: Install modules
         run: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download and install [as with other Drupal modules](https://www.drupal.org/docs/
 For example, using composer from the Drupal site's web directory:
 
 ```
-$ composer require islandora/controlled_access_terms
+$ composer require drupal/controlled_access_terms
 $ drush en -y controlled_access_terms
 ```
 
@@ -120,7 +120,7 @@ displayed. The default setting is YYYY-MM-DD (e.g. 1900-01-31) but settings
 can change, for example, the separator and the date order to display dates in
 'mm/dd/yyyy' format (e.g. 01/31/1900).
 
-[1]: https://github.com/islandora/controlled_access_terms/actions/workflows/build-2.x.yml/badge.svg
+[1]: https://github.com/Islandora/controlled_access_terms/actions/workflows/build-2.x.yml/badge.svg
 [2]: http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg
 [3]: https://img.shields.io/badge/license-GPLv2-blue.svg?style=flat-square
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "islandora/controlled_access_terms",
+  "name": "drupal/controlled_access_terms",
   "description": "Drupal module for subjects and agents",
   "type": "drupal-module",
   "keywords": ["Drupal", "Islandora"],

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
       "url": "https://packages.drupal.org/8"
     }
   ],
+  "replace": {
+    "islandora/controlled_access_terms": "self.version"
+  },
   "require": {
     "drupal/geolocation": "^3.2",
     "drupal/token": "^1.7",


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2270 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

https://groups.google.com/g/islandora/c/brFsDlPRwrI/m/JcgM29OwAAAJ

# What does this Pull Request do?

Changes the name of the module.

# What's new?

* changes islandora/controlled_access_terms to drupal/controlled_access_terms

# How should this be tested?

* On a properly set-up Islandora site, this should be transparent. you should already require drupal/controlled_access_terms. Also you should be getting it from drupal.org.
* It is the desired state that when you `composer require drupal/controlled_access_terms`, you should get it from drupal.org (because you have the drupal composer repository:
``` 
   "repositories": [
        {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        },
    ]
```

This already happens but is due to our syncing to Drupal.org. 
* If you do need to download this code from GitHub (for testing PRs) then add a repository to your composer.json that points to this repo, and position it above the packages.drupal.org/8 one. 
* The only tangible result of this PR is that `composer require islandora/controlled_access_terms` should stop working, which can't be tested until merge.
* Tests still need to pass. I edited the namespace there too.



# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
