### PR TITLE
updated unspecified date output

### DIFF
--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -231,30 +231,30 @@ class EDTFFormatter extends FormatterBase {
     }
 
     // Unspecified.
-    $unspecified = array(
-      'fullyear' => false,
-      'year' => false,
-      'century' => false,
-      'decade' => false,
-      'month' => false,
-      'day' => false,
-    );
+    $unspecified = [
+      'fullyear' => FALSE,
+      'year' => FALSE,
+      'century' => FALSE,
+      'decade' => FALSE,
+      'month' => FALSE,
+      'day' => FALSE,
+    ];
     $unspecified_count = 0;
 
     if (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XXXX') !== FALSE) {
-      $unspecified['fullyear'] = true;
+      $unspecified['fullyear'] = TRUE;
       $unspecified_count++;
     }
     elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XXX') !== FALSE) {
-      $unspecified['century'] = true;
+      $unspecified['century'] = TRUE;
       $unspecified_count++;
     }
     elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XX') !== FALSE) {
-      $unspecified['decade'] = true;
+      $unspecified['decade'] = TRUE;
       $unspecified_count++;
     }
     elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'X') !== FALSE) {
-      $unspecified['year'] = true;
+      $unspecified['year'] = TRUE;
       $unspecified_count++;
     }
 
@@ -262,7 +262,7 @@ class EDTFFormatter extends FormatterBase {
 
     if (array_key_exists(EDTFUtils::MONTH, $parsed_date)) {
       if (strpos($parsed_date[EDTFUtils::MONTH], 'X') !== FALSE) {
-        $unspecified['month'] = true;
+        $unspecified['month'] = TRUE;
         $unspecified_count++;
       }
       elseif ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
@@ -282,7 +282,7 @@ class EDTFFormatter extends FormatterBase {
 
     if (array_key_exists(EDTFUtils::DAY, $parsed_date)) {
       if (strpos($parsed_date[EDTFUtils::DAY], 'X') !== FALSE) {
-        $unspecified['day'] = true;
+        $unspecified['day'] = TRUE;
         $unspecified_count++;
       }
       elseif ($settings['day_format'] === 'd') {
@@ -308,7 +308,7 @@ class EDTFFormatter extends FormatterBase {
       }
     }
 
-    // Replace Xs with 0s and format date parts
+    // Replace Xs with 0s and format date parts.
     if ($unspecified_count > 0) {
       if (strpos($year, 'X') !== FALSE) {
         $year = str_replace('X', '0', $year) . 's';
@@ -346,75 +346,107 @@ class EDTFFormatter extends FormatterBase {
       $parts_in_order = [$year, $month, $day];
     }
 
-    // Special cases for middle endian dates separated by spaces, with months spelled out
-    // Full dates will have a comma before the year, like January 1, 1999
-    // Dates with Xs in them will be written out more verbosely
+    // Special cases for middle endian dates separated by spaces, with months spelled out.
+    // Full dates will have a comma before the year, like January 1, 1999.
+    // Dates with Xs in them will be written out more verbosely.
     $d = intval($day);
     $day_suffix = date('S',mktime(1, 1, 1, 1, ((($d >= 10) + ($d >= 20) + ($d == 0)) * 10 + $d % 10)));
     if ($settings['date_order'] === 'middle_endian' &&
         !preg_match('/\d/', $month) &&
         self::DELIMITERS[$settings['date_separator']] == ' ' &&
         count(array_filter([$month, $day])) > 0) {
-      // Unknown year only
+      // Unknown year only.
       if (!$unspecified['day'] && !$unspecified['month'] && $unspecified_count === 1) {
-        $formatted_date = t(trim("$month $day") . ", of an $year");
+        $formatted_date = t("@md, of an @year", [
+          "@md" => trim("$month $day"),
+          "@year" => $year,
+        ]);
       }
-      // Unknown month only
-      elseif($unspecified['month'] && $unspecified_count === 1) {
+      // Unknown month only.
+      elseif ($unspecified['month'] && $unspecified_count === 1) {
         if ($day !== '') {
           $day .= "$day_suffix day of an";
         }
-        $formatted_date = t(trim("$day $month, in $year"));
+        $formatted_date = t("@dm, in @year", [
+          "@dm" => trim("$day $month"),
+          "@year" => $year,
+        ]);
       }
-      // Unknown day only
-      elseif($unspecified['day'] && $unspecified_count === 1) {
-        $formatted_date = t("$day in $month, $year");
+      // Unknown day only.
+      elseif ($unspecified['day'] && $unspecified_count === 1) {
+        $formatted_date = t("@day in @month, @year", [
+          "@day" => $day,
+          "@month" => $month,
+          "@year" => $year,
+        ]);
       }
-      // Unknown year and month only
-      elseif(!$unspecified['day'] && $unspecified_count === 2) {
+      // Unknown year and month only.
+      elseif (!$unspecified['day'] && $unspecified_count === 2) {
         if ($day !== '') {
           $day .= "$day_suffix day of an";
         }
         if ($year == 'unknown year') {
-          $formatted_date = t("$day $month, in an $year");
+          $formatted_date = t("@day @month, in an @year", [
+          "@day" => $day,
+          "@month" => $month,
+          "@year" => $year,
+        ]);
         }
         else {
-          $formatted_date = t(trim("$day $month, in the " . str_replace('unknown year in the ', '', $year)));
+          $formatted_date = t("@dm, in the @year", [
+            "@dm" => trim("$day $month"),
+            "@year" => str_replace('unknown year in the ', '', $year),
+          ]);
         }
       }
-      // Unknown year and day only
-      elseif(!$unspecified['month'] && $unspecified_count === 2) {
+      // Unknown year and day only.
+      elseif (!$unspecified['month'] && $unspecified_count === 2) {
         if ($year == 'unknown year') {
-          $formatted_date = t("$day in $month, in an $year");
+          $formatted_date = t("@day in @month, in an @year", [
+            "@day" => $day,
+            "@month" => $month,
+            "@year" => $year,
+          ]);
         }
         else {
-          $formatted_date = t("$day in $month, in the " . str_replace('unknown year in the ', '', $year));
+          $formatted_date = t("@day in @month, in the @year", [
+            "@day" => $day,
+            "@month" => $month,
+            "@year" => str_replace('unknown year in the ', '', $year),
+          ]);
         }
       }
-      // Unknown day and month only
-      elseif($unspecified['day'] && $unspecified['month'] && $unspecified_count === 2) {
-        $formatted_date = t("Unknown date, in $year");
+      // Unknown day and month only.
+      elseif ($unspecified['day'] && $unspecified['month'] && $unspecified_count === 2) {
+        $formatted_date = t("Unknown date, in @year", [
+          "@year" => $year,
+        ]);
       }
-      // Unknown year, month, and day
-      elseif($unspecified_count === 3) {
+      // Unknown year, month, and day.
+      elseif ($unspecified_count === 3) {
         if ($year == 'unknown year') {
           $formatted_date = t("Unknown day, month, and year");
         }
         else {
-          $formatted_date = t("Unknown date, in the " . str_replace('unknown year in the ', '', $year));
+          $formatted_date = t("Unknown date, in the @year", [
+            "@year" => str_replace('unknown year in the ', '', $year),
+          ]);
         }
       }
-      // No unknown segments
-      // Adds a comma after the month & day as long as there is at least one of them
+      // No unknown segments.
+      // Adds a comma after the month & day as long as there is at least one of them.
       else {
-        $formatted_date = t(trim("$month $day") . ", $year");
+        $formatted_date = t("@md, @year", [
+          "@md" => trim("$month $day"),
+          "@year" => $year,
+        ]);
       }
     }
     else {
       $formatted_date = t(implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order)));
     }
 
-    // Capitalize first letter for unknown dates
+    // Capitalize first letter for unknown dates.
     if ($unspecified_count > 0) {
       $formatted_date = ucfirst($formatted_date);
     }

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -346,11 +346,11 @@ class EDTFFormatter extends FormatterBase {
       $parts_in_order = [$year, $month, $day];
     }
 
-    // Special cases for middle endian dates separated by spaces, with months spelled out.
+    // Special cases for middle endian dates with spaces and months spelled out.
     // Full dates will have a comma before the year, like January 1, 1999.
     // Dates with Xs in them will be written out more verbosely.
     $d = intval($day);
-    $day_suffix = date('S',mktime(1, 1, 1, 1, ((($d >= 10) + ($d >= 20) + ($d == 0)) * 10 + $d % 10)));
+    $day_suffix = date('S', mktime(1, 1, 1, 1, ((($d >= 10) + ($d >= 20) + ($d == 0)) * 10 + $d % 10)));
     if ($settings['date_order'] === 'middle_endian' &&
         !preg_match('/\d/', $month) &&
         self::DELIMITERS[$settings['date_separator']] == ' ' &&
@@ -387,10 +387,10 @@ class EDTFFormatter extends FormatterBase {
         }
         if ($year == 'unknown year') {
           $formatted_date = t("@day @month, in an @year", [
-          "@day" => $day,
-          "@month" => $month,
-          "@year" => $year,
-        ]);
+            "@day" => $day,
+            "@month" => $month,
+            "@year" => $year,
+          ]);
         }
         else {
           $formatted_date = t("@dm, in the @year", [
@@ -434,7 +434,7 @@ class EDTFFormatter extends FormatterBase {
         }
       }
       // No unknown segments.
-      // Adds a comma after the month & day as long as there is at least one of them.
+      // Adds a comma after the month & day.
       else {
         $formatted_date = t("@md, @year", [
           "@md" => trim("$month $day"),
@@ -443,7 +443,9 @@ class EDTFFormatter extends FormatterBase {
       }
     }
     else {
-      $formatted_date = t(implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order)));
+      $formatted_date = t("@date", [
+        "@date" => implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order))
+      ]);
     }
 
     // Capitalize first letter for unknown dates.

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -444,7 +444,7 @@ class EDTFFormatter extends FormatterBase {
     }
     else {
       $formatted_date = t("@date", [
-        "@date" => implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order))
+        "@date" => implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order)),
       ]);
     }
 

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -310,8 +310,9 @@ class EDTFFormatter extends FormatterBase {
 
     // Replace Xs with 0s and format date parts
     if ($unspecified_count > 0) {
-      if (strpos($year, 'X') !== FALSE)
+      if (strpos($year, 'X') !== FALSE) {
         $year = str_replace('X', '0', $year) . 's';
+      }
 
       if ($unspecified['fullyear']) {
         $year = 'unknown year';
@@ -349,7 +350,7 @@ class EDTFFormatter extends FormatterBase {
     // Full dates will have a comma before the year, like January 1, 1999
     // Dates with Xs in them will be written out more verbosely
     $d = intval($day);
-    $day_suffix = date('S',mktime(1,1,1,1,( (($d>=10)+($d>=20)+($d==0))*10 + $d%10) ));
+    $day_suffix = date('S',mktime(1, 1, 1, 1, ((($d >= 10) + ($d >= 20) + ($d == 0)) * 10 + $d % 10)));
     if ($settings['date_order'] === 'middle_endian' &&
         !preg_match('/\d/', $month) &&
         self::DELIMITERS[$settings['date_separator']] == ' ' &&
@@ -360,8 +361,9 @@ class EDTFFormatter extends FormatterBase {
       }
       // Unknown month only
       elseif($unspecified['month'] && $unspecified_count === 1) {
-        if ($day !== '')
+        if ($day !== '') {
           $day .= "$day_suffix day of an";
+        }
         $formatted_date = t(trim("$day $month, in $year"));
       }
       // Unknown day only
@@ -370,19 +372,24 @@ class EDTFFormatter extends FormatterBase {
       }
       // Unknown year and month only
       elseif(!$unspecified['day'] && $unspecified_count === 2) {
-        if ($day !== '')
+        if ($day !== '') {
           $day .= "$day_suffix day of an";
-        if ($year == 'unknown year')
+        }
+        if ($year == 'unknown year') {
           $formatted_date = t("$day $month, in an $year");
-        else
+        }
+        else {
           $formatted_date = t(trim("$day $month, in the " . str_replace('unknown year in the ', '', $year)));
+        }
       }
       // Unknown year and day only
       elseif(!$unspecified['month'] && $unspecified_count === 2) {
-        if ($year == 'unknown year')
+        if ($year == 'unknown year') {
           $formatted_date = t("$day in $month, in an $year");
-        else
+        }
+        else {
           $formatted_date = t("$day in $month, in the " . str_replace('unknown year in the ', '', $year));
+        }
       }
       // Unknown day and month only
       elseif($unspecified['day'] && $unspecified['month'] && $unspecified_count === 2) {
@@ -390,10 +397,12 @@ class EDTFFormatter extends FormatterBase {
       }
       // Unknown year, month, and day
       elseif($unspecified_count === 3) {
-        if ($year == 'unknown year')
+        if ($year == 'unknown year') {
           $formatted_date = t("Unknown day, month, and year");
-        else
+        }
+        else {
           $formatted_date = t("Unknown date, in the " . str_replace('unknown year in the ', '', $year));
+        }
       }
       // No unknown segments
       // Adds a comma after the month & day as long as there is at least one of them
@@ -406,8 +415,9 @@ class EDTFFormatter extends FormatterBase {
     }
 
     // Capitalize first letter for unknown dates
-    if ($unspecified_count > 0)
+    if ($unspecified_count > 0) {
       $formatted_date = ucfirst($formatted_date);
+    }
 
     // Time.
     // @todo Add time formatting options.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/controlled_access_terms/issues/133

# What does this Pull Request do?

Changes the way the EDTF formatter outputs dates with Xs in them. Previously there were several dates that would not display correctly, as noted in the issue above.

# What's new?

With this PR, they will now be labelled as unknown dates instead of unspecified dates

Also changed wording of years to better represent that they refer to a year in the decade, century, millennium, rather than the whole decade, century or millennium.

For middle endian dates, separated by spaces, and with the month spelled out (eg. January 1, 1999), this also adds a lot of extra formatting to write those unknown dates out in a more verbose manner that should make sense to site users who don't have archival backgrounds. Also, should not be ambiguous with regard to the difference between 190X and 19XX as it will state if it is a century or a decade.

The output with this PR should now look like this:

Input | middle endian, spaces, month in   letters (before this PR) | middle endian, spaces, month in   letters (after this PR)
-- | -- | --
1999 | 1999 | 1999
1999-01 | January   1999 | January, 1999
1999-01-01 | January   1, 1999 | January 1, 1999
199X | unspecified   year in 199X | Unknown year in the decade of the 1990s
19XX | unspecified   decade in 19XX | Unknown year in the century of the 1900s
1XXX | unspecified   century in 1XXX | Unknown year in the millennium of the 1000s
XXXX | unspecified   year in XXXX | Unknown year
1999-XX | unspecified   month in 1999 | Unknown month, in 1999
199X-XX | unspecified   year and month in 199X | Unknown month, in the decade of the 1990s
199X-01 | unspecified   year in January 199X | January, of an unknown year in the decade of the 1990s
19XX-01 | unspecified   decade in January 19XX | January, of an unknown year in the century of the 1900s
1XXX-01 | unspecified   century in January 1XXX | January, of an unknown year in the millennium of the 1000s
1999-01-XX | unspecified   day in January 1999 | Unknown day in January, 1999
1999-XX-XX | unspecified   month and day in 1999 | Unknown date, in 1999
199X-XX-XX | unspecified   year, month, and day in 199X | Unknown date, in the decade of the 1990s
XXXX-XX-XX | unspecified   year, month, and day in XXXX | Unknown day, month, and year
19XX-XX-XX | unspecified   decade, month, and day in 19XX | Unknown date, in the century of the 1900s
1XXX-XX-XX | unspecified   century, month, and day in 1XXX | Unknown date, in the millennium of the 1000s
1999-XX-01 | unspecified   month in 1, 1999 | 1st day of an unknown month, in 1999
199X-XX-01 | unspecified   year and month in 1, 199X | 1st day of an unknown month, in the decade of the 1990s
19XX-01-XX | unspecified   decade and day in January 19XX | Unknown day in January, in the century of the 1900s
190X-01-XX | unspecified   year and day in January 190X | Unknown day in January, in the decade of the 1900s
XXXX-XX-01 | unspecified   year and month in 1, XXXX | 1st day of an unknown month, in an unknown year
XXXX-12-XX | unspecified   year and day in December XXXX | Unknown day in December, in an unknown year
192X-01-01 | unspecified   year in January 1, 192X | January 1, of an unknown year in the decade of the 1920s

Input | little endian, slashes, 2 digit   month & day (before this PR) | little endian, slashes, 2 digit   month & day (after this PR)
-- | -- | --
1999 | 1999 | 1999
1999-01 | 01/1999 | 01/1999
1999-01-01 | 01/01/1999 | 01/01/1999
199X | unspecified   year in 199X | Unknown year in the decade of the 1990s
19XX | unspecified   decade in 19XX | Unknown year in the century of the 1900s
1XXX | unspecified   century in 1XXX | Unknown year in the millennium of the 1000s
XXXX | unspecified   year in XXXX | Unknown year
1999-XX | unspecified   month in 1999 | Unknown month/1999
199X-XX | unspecified   year and month in 199X | Unknown month/unknown year in the decade of the 1990s
199X-01 | unspecified   year in 01/199X | 01/unknown year in the decade of the 1990s
19XX-01 | unspecified   decade in 01/19XX | 01/unknown year in the century of the 1900s
1XXX-01 | unspecified   century in 01/1XXX | 01/unknown year in the millennium of the 1000s
1999-01-XX | unspecified   day in 01/1999 | Unknown day/01/1999
1999-XX-XX | unspecified   month and day in 1999 | Unknown day/unknown month/1999
199X-XX-XX | unspecified   year, month, and day in 199X | Unknown day/unknown month/unknown year in the decade of the   1990s
XXXX-XX-XX | unspecified   year, month, and day in XXXX | Unknown day/unknown month/unknown year
19XX-XX-XX | unspecified   decade, month, and day in 19XX | Unknown day/unknown month/unknown year in the century of the   1900s
1XXX-XX-XX | unspecified   century, month, and day in 1XXX | Unknown day/unknown month/unknown year in the millennium of   the 1000s
1999-XX-01 | unspecified   month in 01/1999 | 01/unknown month/1999
199X-XX-01 | unspecified   year and month in 01/199X | 01/unknown month/unknown year in the decade of the 1990s
19XX-01-XX | unspecified   decade and day in 01/19XX | Unknown day/01/unknown year in the century of the 1900s
190X-01-XX | unspecified   year and day in 01/190X | Unknown day/01/unknown year in the decade of the 1900s
XXXX-XX-01 | unspecified   year and month in 01/XXXX | 01/unknown month/unknown year
XXXX-12-XX | unspecified   year and day in 12/XXXX | Unknown day/12/unknown year
192X-01-01 | unspecified   year in 01/01/192X | 01/01/unknown year in the decade of the 1920s

# How should this be tested?

Add some dates with Xs in them. Test the EDTF formatter with and without this PR to see the difference.

# Additional Notes:
N/A

# Interested parties
@Islandora/committers
