### PR TITLE
Issue 137 - Allow formatter to set url_only and url_plain.

### DIFF
--- a/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
@@ -76,9 +76,13 @@ class AuthorityLinkFormatter extends LinkFormatter {
       if (!empty($settings['trim_length'])) {
         $link_title = Unicode::truncate($link_title, $settings['trim_length'], FALSE, TRUE);
       }
+      if (!empty($settings['url_only']) && empty($settings['url_plain'])) {
+        $link_title = $url->toString();
+      }
+
       if (!empty($settings['url_only']) && !empty($settings['url_plain'])) {
         $element[$delta] = [
-          '#plain_text' => $link_title,
+          '#plain_text' => $url->toString(),
         ];
         if (!empty($item->_attributes)) {
 

--- a/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
@@ -32,6 +32,15 @@ class AuthorityLinkFormatter extends LinkFormatter {
   /**
    * {@inheritdoc}
    */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+    $form['url_only']['#access'] = $form['url_plain']['#access'] = ($this->getPluginId() == 'authority_formatter_default');
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $element = [];
     $entity = $items

--- a/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AuthorityLinkFormatter.php
@@ -4,6 +4,7 @@ namespace Drupal\controlled_access_terms\Plugin\Field\FieldFormatter;
 
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\link\Plugin\Field\FieldFormatter\LinkFormatter;
 
 /**


### PR DESCRIPTION
**GitHub Issue**: #137 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Puts the "URL only" and "Show URL as plain text" checkboxes on the field formatter settings page for authority links
 
# What's new?

* The parent, LinkFormatter, "locked down" those fields from inheriting classes by setting their access to true only if you're in a Link Formatter. This PR does the same, setting their access to  true if you're in an Authority Link formatter.
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

A description of what steps someone could take to:
* Reproduce instructions are in #137.
* With this PR, the Authority Link formatter should also show "URL only" and, if that's checked, the other checkbox.


# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
