### PR TITLE
EDTF Full Date Processor

### DIFF
--- a/src/Plugin/search_api/processor/EDTFDateProcessor.php
+++ b/src/Plugin/search_api/processor/EDTFDateProcessor.php
@@ -11,7 +11,7 @@ use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-
+use Drupal\controlled_access_terms\EDTFUtils;
 
 /**
  * Provides a Search API processor for indexing EDTF dates (single and multiple dates) in Solr.
@@ -34,68 +34,66 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
      * @var array Stores plugin configuration 
      */
     protected $configuration;
-
+  
     /**
      * {@inheritdoc}
      */
     public function defaultConfiguration()
     {
         return [
-        'fields' => [],
-        'ignore_open_start' => false,
-        'ignore_open_end' => false,
-        'open_start_year' => 0,
-        'open_end_year' => '',
+            'fields' => [],
+            'ignore_open_start' => false,
+            'ignore_open_end' => false,
+            'open_start_year' => 0,
+            'open_end_year' => '',
         ];
     }
-
+  
     /**
      * {@inheritdoc}
      */
     public function buildConfigurationForm(array $form, FormStateInterface $form_state)
     {
         $form['#description'] = $this->t('Select the EDTF fields to extract dates from.');
-
+  
         $fields = \Drupal::entityTypeManager()
             ->getStorage('field_config')
             ->loadByProperties(['field_type' => 'edtf']);
-
+  
         $fields_options = [];
         foreach ($fields as $field) {
             $key = $field->getTargetEntityTypeId() . '|' . $field->getName();
-            $fields_options[$key] = $this->t(
-                '@label (Entity: @entity_type)', [
+            $fields_options[$key] = $this->t('@label (Entity: @entity_type)', [
                 '@label' => $field->label(),
                 '@entity_type' => $field->getTargetEntityTypeId(),
-                ]
-            );
+            ]);
         }
-
+  
         $form['fields'] = [
-        '#type' => 'select',
-        '#multiple' => true,
-        '#title' => $this->t('EDTF Fields'),
-        '#description' => $this->t('Select one or more EDTF fields to index.'),
-        '#options' => $fields_options,
-        '#default_value' => $this->configuration['fields'],
+            '#type' => 'select',
+            '#multiple' => true,
+            '#title' => $this->t('EDTF Fields'),
+            '#description' => $this->t('Select one or more EDTF fields to index.'),
+            '#options' => $fields_options,
+            '#default_value' => $this->configuration['fields'],
         ];
-
+  
         $form['open_start_year'] = [
-        '#type' => 'number',
-        '#title' => $this->t('Open Interval Begin Year'),
-        '#description' => $this->t('Sets the begging year to begin indexing from. Leave blank if you would like to index from the smallest year found in the data.'),
-        '#default_value' => $this->configuration['open_start_year'],
+            '#type' => 'number',
+            '#title' => $this->t('Open Interval Begin Year'),
+            '#description' => $this->t('Sets the beginning year to begin indexing from. Leave blank if you would like to index from the smallest year found in the data.'),
+            '#default_value' => $this->configuration['open_start_year'],
         ];
         $form['open_end_year'] = [
-        '#type' => 'number',
-        '#title' => $this->t('Open Interval End Year'),
-        '#description' => $this->t('Sets the end year to end indexing at. Leave blank if you would like to indext to the largest year found in the data.'),
-        '#default_value' => $this->configuration['open_end_year'],
+            '#type' => 'number',
+            '#title' => $this->t('Open Interval End Year'),
+            '#description' => $this->t('Sets the end year to end indexing at. Leave blank if you would like to index to the largest year found in the data.'),
+            '#default_value' => $this->configuration['open_end_year'],
         ];
-
+  
         return $form;
     }
-
+  
     /**
      * {@inheritdoc}
      */
@@ -110,7 +108,6 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
         }
     }
   
-
     /**
      * {@inheritdoc}
      */
@@ -122,7 +119,7 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
         $this->configuration['open_start_year'] = $form_state->getValue('open_start_year');
         $this->configuration['open_end_year'] = $form_state->getValue('open_end_year');
     }
-
+  
     /**
      * {@inheritdoc}
      */
@@ -135,21 +132,19 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
                 ->setLabel($this->t('EDTF Dates'))
                 ->setDescription($this->t('Indexes single EDTF dates or multiple separate dates.'));
         
-            $properties['edtf_dates'] = new ProcessorProperty(
-                [
+            $properties['edtf_dates'] = new ProcessorProperty([
                 'label' => $this->t('EDTF Dates'),
                 'description' => $this->t('Indexes single EDTF dates or multiple separate dates.'),
                 'type' => 'datetime_iso8601',
                 'is_list' => true,
                 'processor_id' => $this->getPluginId(),
                 'data_definition' => $data_definition,
-                ]
-            );
+            ]);
         }
-
+  
         return $properties;
     }
-
+  
     /**
      * {@inheritdoc}
      */
@@ -157,11 +152,11 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
     {
         $entity = $item->getOriginalObject()->getValue();
         $edtfDates = [];
-
+  
         foreach ($this->configuration['fields'] as $field_key) {
             if (strpos($field_key, '|') === false) {
                 continue;
-            }      
+            }
             [$entity_type, $field_name] = explode('|', $field_key, 2);
             if ($entity->getEntityTypeId() !== $entity_type) {
                 continue;
@@ -173,8 +168,9 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
             $field_values = $entity->get($field_name)->getValue();
             foreach ($field_values as $date_item) {
                 if (!empty($date_item['value'])) {
-                    $value = $date_item['value'];
-
+                    // Sanitize the input value before processing.
+                    $value = $this->sanitizeEDTFString($date_item['value']);
+  
                     if ($this->isSingleEDTFDate($value)) {
                         $edtfDates[] = $this->convertEDTFtoSolr($value);
                     }
@@ -187,6 +183,7 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
                 }
             }
         }
+  
         $filteredDates = [];
         foreach ($edtfDates as $date) {
             $year = (int) substr($date, 0, 4);
@@ -199,14 +196,12 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
             $filteredDates[] = $date;
         }
         $edtfDates = $filteredDates;
-
+  
         // Sort dates in ascending order.
-        usort(
-            $edtfDates, function ($a, $b) {
-                return strtotime($a) - strtotime($b);
-            }
-        );
-
+        usort($edtfDates, function ($a, $b) {
+            return strtotime($a) - strtotime($b);
+        });
+  
         if (!empty($edtfDates)) {
             $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), null, 'edtf_dates');
             foreach ($fields as $field) {
@@ -214,7 +209,7 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
             }
         }
     }
-
+  
     /**
      * Checks if the provided value is a single (possibly incomplete) EDTF date.
      *
@@ -222,50 +217,113 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
      * - YYYY (e.g. "2012")
      * - YYYY-MM (e.g. "2012-05")
      * - YYYY-MM-DD (e.g. "2012-05-01")
+     *
+     * Allows X placeholders.
      */
     protected function isSingleEDTFDate($value)
     {
-        return (bool) preg_match('/^\d{4}(-\d{2}(-\d{2})?)?$/', $value);
+        return is_string($value) && preg_match('/^[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?$/', $value);
     }
-
+  
     /**
      * Checks if the provided value is a multiple EDTF date value (wrapped in curly braces).
+     *
+     * Accepted format:
+     * - {YYYY, YYYY-MM, YYYY-MM-DD, ...}
      */
     protected function isEDTFMultiDate($value)
     {
-        return is_string($value) && preg_match('/^{\s*(\d{4}-\d{2}-\d{2})(\s*,\s*\d{4}-\d{2}-\d{2})*\s*}$/', $value);
+        return is_string($value) && preg_match('/^{\s*([0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)(\s*,\s*[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)*\s*}$/', $value);
     }
-
+  
     /**
-     * Converts a single (possibly incomplete) EDTF date to Solr-compatible format.
+     * Converts a single (possibly incomplete) EDTF date to a Solr-compatible format.
      */
     protected function convertEDTFtoSolr($value)
     {
+        // Sanitize and normalize the EDTF string.
+        $value = $this->sanitizeEDTFString($value);
+        $value = $this->normalizeXPlaceholders($value);
+  
+        // Handle season mapping for YYYY-MM format if applicable.
+        if (preg_match('/^(\d{4})-(\d{2})$/', $value, $matches)) {
+            $year = $matches[1];
+            $month = $matches[2];
+            if (isset(EDTFUtils::SEASONS_MAP[$month])) {
+                $mapped_month = EDTFUtils::SEASONS_MAP[$month];
+                return "{$year}-{$mapped_month}-01T00:00:00Z";
+            }
+        }
+  
+        // Ensure complete date format.
         switch (true) {
-        case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
-            break;
-        case preg_match('/^\d{4}-\d{2}$/', $value):
-            $value .= '-01';
-            break;
-        case preg_match('/^\d{4}$/', $value):
-            $value .= '-01-01';
-            break;
+            case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
+                break;
+            case preg_match('/^\d{4}-\d{2}$/', $value):
+                $value .= '-01';
+                break;
+            case preg_match('/^\d{4}$/', $value):
+                $value .= '-01-01';
+                break;
         }
         return $value . 'T00:00:00Z';
     }
-
+  
     /**
      * Converts a multiple EDTF date value to an array of Solr-compatible dates.
      */
     protected function convertEDTFMultiDateToSolr($value)
     {
-        if (preg_match_all('/\d{4}-\d{2}-\d{2}/', $value, $matches)) {
-            return array_map(
-                function ($date) {
-                    return $date . 'T00:00:00Z';
-                }, $matches[0]
-            );
+        if (preg_match_all('/[0-9X]{4}(?:-[0-9X]{2}(?:-[0-9X]{2})?)?/', $value, $matches)) {
+            $converted = [];
+            foreach ($matches[0] as $raw_date) {
+                $converted[] = $this->convertEDTFtoSolr($raw_date);
+            }
+            return $converted;
         }
         return [];
+    }
+  
+    /**
+     * Removes unwanted special characters from the EDTF string.
+     */
+    protected function sanitizeEDTFString($value)
+    {
+        return str_replace(["~", "?", "%"], "", $value);
+    }
+  
+    /**
+     * Replaces X placeholders in the EDTF string.
+     *
+     * For the year, replaces all X with 0.
+     * For month/day, replaces "XX" with "01", else replaces X with 0 and fixes "00" to "01".
+     */
+    protected function normalizeXPlaceholders($value)
+    {
+        $parts = explode('-', $value);
+        $parts[0] = str_replace('X', '0', $parts[0]);
+        if (isset($parts[1])) {
+            if ($parts[1] === 'XX') {
+                $parts[1] = '01';
+            }
+            else {
+                $parts[1] = str_replace('X', '0', $parts[1]);
+                if ($parts[1] === '00') {
+                    $parts[1] = '01';
+                }
+            }
+        }
+        if (isset($parts[2])) {
+            if ($parts[2] === 'XX') {
+                $parts[2] = '01';
+            }
+            else {
+                $parts[2] = str_replace('X', '0', $parts[2]);
+                if ($parts[2] === '00') {
+                    $parts[2] = '01';
+                }
+            }
+        }
+        return implode('-', $parts);
     }
 }

--- a/src/Plugin/search_api/processor/EDTFDateProcessor.php
+++ b/src/Plugin/search_api/processor/EDTFDateProcessor.php
@@ -30,7 +30,7 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
   /**
    * Stores plugin configuration.
    *
-   * @var array Stores plugin configuration
+   * @var array
    */
   protected $configuration;
 

--- a/src/Plugin/search_api/processor/EDTFDateProcessor.php
+++ b/src/Plugin/search_api/processor/EDTFDateProcessor.php
@@ -6,15 +6,13 @@ use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\controlled_access_terms\EDTFUtils;
 
 /**
- * Provides a Search API processor for indexing EDTF dates (single and multiple dates) in Solr.
+ * Provides a Search API processor for indexing EDTF dates in Solr.
  *
  * @SearchApiProcessor(
  *   id = "edtf_date_processor",
@@ -25,311 +23,374 @@ use Drupal\controlled_access_terms\EDTFUtils;
  *   }
  * )
  */
-class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterface
-{
-    use PluginFormTrait;
-    use StringTranslationTrait;
-  
-    /**
-     * @var array Stores plugin configuration 
-     */
-    protected $configuration;
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function defaultConfiguration()
-    {
-        return [
-            'fields' => [],
-            'ignore_open_start' => false,
-            'ignore_open_end' => false,
-            'open_start_year' => 0,
-            'open_end_year' => '',
-        ];
-    }
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function buildConfigurationForm(array $form, FormStateInterface $form_state)
-    {
-        $form['#description'] = $this->t('Select the EDTF fields to extract dates from.');
-  
-        $fields = \Drupal::entityTypeManager()
-            ->getStorage('field_config')
-            ->loadByProperties(['field_type' => 'edtf']);
-  
-        $fields_options = [];
-        foreach ($fields as $field) {
-            $key = $field->getTargetEntityTypeId() . '|' . $field->getName();
-            $fields_options[$key] = $this->t(
-                '@label (Entity: @entity_type)', [
-                '@label' => $field->label(),
-                '@entity_type' => $field->getTargetEntityTypeId(),
-                ]
-            );
-        }
-  
-        $form['fields'] = [
-            '#type' => 'select',
-            '#multiple' => true,
-            '#title' => $this->t('EDTF Fields'),
-            '#description' => $this->t('Select one or more EDTF fields to index.'),
-            '#options' => $fields_options,
-            '#default_value' => $this->configuration['fields'],
-        ];
-  
-        $form['open_start_year'] = [
-            '#type' => 'number',
-            '#title' => $this->t('Open Interval Begin Year'),
-            '#description' => $this->t('Sets the beginning year to begin indexing from. Leave blank if you would like to index from the smallest year found in the data.'),
-            '#default_value' => $this->configuration['open_start_year'],
-        ];
-        $form['open_end_year'] = [
-            '#type' => 'number',
-            '#title' => $this->t('Open Interval End Year'),
-            '#description' => $this->t('Sets the end year to end indexing at. Leave blank if you would like to index to the largest year found in the data.'),
-            '#default_value' => $this->configuration['open_end_year'],
-        ];
-  
-        return $form;
-    }
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function validateConfigurationForm(array &$form, FormStateInterface $form_state)
-    {
-        if ($form_state->getValue('open_start_year') < 0) {
-            $form_state->setErrorByName('open_start_year', $this->t('Open start year must be a positive integer.'));
-        }
-    
-        if (!empty($form_state->getValue('open_end_year')) && $form_state->getValue('open_end_year') < $form_state->getValue('open_start_year')) {
-            $form_state->setErrorByName('open_end_year', $this->t('Open end year must be greater than or equal to open start year.'));
-        }
-    }
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function submitConfigurationForm(array &$form, FormStateInterface $form_state)
-    {
-        $this->configuration['fields'] = $form_state->getValue('fields', []);
-        $this->configuration['ignore_open_start'] = $form_state->getValue('ignore_open_start');
-        $this->configuration['ignore_open_end'] = $form_state->getValue('ignore_open_end');
-        $this->configuration['open_start_year'] = $form_state->getValue('open_start_year');
-        $this->configuration['open_end_year'] = $form_state->getValue('open_end_year');
-    }
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function getPropertyDefinitions(?DatasourceInterface $datasource = null)
-    {
-        $properties = [];
-    
-        if (!$datasource) {
-            $data_definition = \Drupal::typedDataManager()->createDataDefinition('datetime_iso8601')
-                ->setLabel($this->t('EDTF Dates'))
-                ->setDescription($this->t('Indexes single EDTF dates or multiple separate dates.'));
-        
-            $properties['edtf_dates'] = new ProcessorProperty(
-                [
-                'label' => $this->t('EDTF Dates'),
-                'description' => $this->t('Indexes single EDTF dates or multiple separate dates.'),
-                'type' => 'datetime_iso8601',
-                'is_list' => true,
-                'processor_id' => $this->getPluginId(),
-                'data_definition' => $data_definition,
-                ]
-            );
-        }
-  
-        return $properties;
-    }
-  
-    /**
-     * {@inheritdoc}
-     */
-    public function addFieldValues(ItemInterface $item)
-    {
-        $entity = $item->getOriginalObject()->getValue();
-        $edtfDates = [];
-  
-        foreach ($this->configuration['fields'] as $field_key) {
-            if (strpos($field_key, '|') === false) {
-                continue;
-            }
-            [$entity_type, $field_name] = explode('|', $field_key, 2);
-            if ($entity->getEntityTypeId() !== $entity_type) {
-                continue;
-            }
-            if (!$entity->hasField($field_name)) {
-                continue;
-            }
-      
-            $field_values = $entity->get($field_name)->getValue();
-            foreach ($field_values as $date_item) {
-                if (!empty($date_item['value'])) {
-                    // Sanitize the input value before processing.
-                    $value = $this->sanitizeEDTFString($date_item['value']);
-  
-                    if ($this->isSingleEDTFDate($value)) {
-                        $edtfDates[] = $this->convertEDTFtoSolr($value);
-                    }
-                    elseif ($this->isEDTFMultiDate($value)) {
-                        $dates = $this->convertEDTFMultiDateToSolr($value);
-                        if ($dates) {
-                            $edtfDates = array_merge($edtfDates, $dates);
-                        }
-                    }
-                }
-            }
-        }
-  
-        $filteredDates = [];
-        foreach ($edtfDates as $date) {
-            $year = (int) substr($date, 0, 4);
-            if (!$this->configuration['ignore_open_start'] && $this->configuration['open_start_year'] > 0 && $year < $this->configuration['open_start_year']) {
-                continue;
-            }
-            if (!$this->configuration['ignore_open_end'] && !empty($this->configuration['open_end_year']) && $year > $this->configuration['open_end_year']) {
-                continue;
-            }
-            $filteredDates[] = $date;
-        }
-        $edtfDates = $filteredDates;
-  
-        // Sort dates in ascending order.
-        usort(
-            $edtfDates, function ($a, $b) {
-                return strtotime($a) - strtotime($b);
-            }
+class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterface {
+  use PluginFormTrait;
+  use StringTranslationTrait;
+
+  /**
+   * Stores plugin configuration.
+   *
+   * @var array Stores plugin configuration
+   */
+  protected $configuration;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'fields' => [],
+      'open_start_year' => 0,
+      'open_end_year' => '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['#description'] = $this->t('Select the EDTF fields to extract dates from.
+            <br>Note: The following EDTF date formats are supported:
+                <ul>
+                <li>Year only: YYYY (e.g. "2012")</li>
+                <li>Year and month only: YYYY-MM (e.g. "2012-05")</li>
+                <li>Full date: YYYY-MM-DD (e.g. "2012-05-01")</li>
+                <li>Multiple dates:{YYYY, YYYY-MM, YYYY-MM-DD, ...}</li>
+                <li>Date ranges: YYYY/YYYY</li>
+                <li> Dates with unknown parts: YYYY-X, YYYY-MM-X, YYYY-MM-DD-X</li>
+                <ul>');
+
+    $fields = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->loadByProperties(['field_type' => 'edtf']);
+
+    $fields_options = [];
+    foreach ($fields as $field) {
+      $key = $field->getTargetEntityTypeId() . '|' . $field->getName();
+      $fields_options[$key] = $this->t(
+            '@label (Entity: @entity_type)', [
+              '@label' => $field->label(),
+              '@entity_type' => $field->getTargetEntityTypeId(),
+            ]
         );
-  
-        if (!empty($edtfDates)) {
-            $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), null, 'edtf_dates');
-            foreach ($fields as $field) {
-                $field->setValues($edtfDates);
+    }
+
+    $form['fields'] = [
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => $this->t('EDTF Fields'),
+      '#description' => $this->t('Select one or more EDTF fields to index.'),
+      '#options' => $fields_options,
+      '#default_value' => $this->configuration['fields'],
+    ];
+
+    $form['open_start_year'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Open Interval Begin Year'),
+      '#description' => $this->t('Sets the beginning year to begin indexing from. Leave blank if you would like to index from year 1000.'),
+      '#default_value' => $this->configuration['open_start_year'],
+    ];
+    $form['open_end_year'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Open Interval End Year'),
+      '#description' => $this->t('Sets the end year to end indexing at. Leave blank if you would like to index up to date 9999.'),
+      '#default_value' => $this->configuration['open_end_year'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    if ($form_state->getValue('open_start_year') < 0) {
+      $form_state->setErrorByName('open_start_year', $this->t('Open start year must be a positive integer.'));
+    }
+
+    if (!empty($form_state->getValue('open_end_year')) && $form_state->getValue('open_end_year') < $form_state->getValue('open_start_year')) {
+      $form_state->setErrorByName('open_end_year', $this->t('Open end year must be greater than or equal to open start year.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['fields'] = $form_state->getValue('fields', []);
+    $this->configuration['ignore_open_start'] = $form_state->getValue('ignore_open_start');
+    $this->configuration['ignore_open_end'] = $form_state->getValue('ignore_open_end');
+    $this->configuration['open_start_year'] = $form_state->getValue('open_start_year');
+    $this->configuration['open_end_year'] = $form_state->getValue('open_end_year');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $data_definition = \Drupal::typedDataManager()->createDataDefinition('datetime_iso8601')
+        ->setLabel($this->t('EDTF Dates'))
+        ->setDescription($this->t('Indexes single EDTF dates or multiple separate dates.'));
+
+      $properties['edtf_dates'] = new ProcessorProperty(
+            [
+              'label' => $this->t('EDTF Dates'),
+              'description' => $this->t('Indexes single EDTF dates or multiple separate dates.'),
+              'type' => 'datetime_iso8601',
+              'is_list' => TRUE,
+              'processor_id' => $this->getPluginId(),
+              'data_definition' => $data_definition,
+            ]
+        );
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $entity = $item->getOriginalObject()->getValue();
+    $edtfDates = [];
+
+    foreach ($this->configuration['fields'] as $field_key) {
+      if (strpos($field_key, '|') === FALSE) {
+        continue;
+      }
+      [$entity_type, $field_name] = explode('|', $field_key, 2);
+      if ($entity->getEntityTypeId() !== $entity_type) {
+        continue;
+      }
+      if (!$entity->hasField($field_name)) {
+        continue;
+      }
+
+      $field_values = $entity->get($field_name)->getValue();
+      foreach ($field_values as $date_item) {
+        if (!empty($date_item['value'])) {
+          // Sanitize the input value before processing.
+          $value = $this->sanitizeEdtfString($date_item['value']);
+
+          if ($this->isSingleEdtfDate($value)) {
+            $edtfDates[] = $this->convertEdtftoSolr($value);
+          }
+          elseif ($this->isEdtfMultiDate($value)) {
+            $dates = $this->convertEdtfMultiDateToSolr($value);
+            if ($dates) {
+              $edtfDates = array_merge($edtfDates, $dates);
             }
+          }
         }
+      }
     }
-  
-    /**
-     * Checks if the provided value is a single (possibly incomplete) EDTF date.
-     *
-     * Accepted formats:
-     * - YYYY (e.g. "2012")
-     * - YYYY-MM (e.g. "2012-05")
-     * - YYYY-MM-DD (e.g. "2012-05-01")
-     *
-     * Allows X placeholders.
-     */
-    protected function isSingleEDTFDate($value)
-    {
-        return is_string($value) && preg_match('/^[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?$/', $value);
+
+    $filteredDates = [];
+    foreach ($edtfDates as $date) {
+      $year = (int) substr($date, 0, 4);
+      if (!$this->configuration['ignore_open_start'] && $this->configuration['open_start_year'] > 0 && $year < $this->configuration['open_start_year']) {
+        continue;
+      }
+      if (!$this->configuration['ignore_open_end'] && !empty($this->configuration['open_end_year']) && $year > $this->configuration['open_end_year']) {
+        continue;
+      }
+      $filteredDates[] = $date;
     }
-  
-    /**
-     * Checks if the provided value is a multiple EDTF date value (wrapped in curly braces).
-     *
-     * Accepted format:
-     * - {YYYY, YYYY-MM, YYYY-MM-DD, ...}
-     */
-    protected function isEDTFMultiDate($value)
-    {
-        return is_string($value) && preg_match('/^{\s*([0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)(\s*,\s*[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)*\s*}$/', $value);
+    $edtfDates = $filteredDates;
+
+    // Sort dates in ascending order.
+    usort(
+          $edtfDates, function ($a, $b) {
+              return strtotime($a) - strtotime($b);
+          }
+      );
+
+    if (!empty($edtfDates)) {
+      $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), NULL, 'edtf_dates');
+      foreach ($fields as $field) {
+        $field->setValues($edtfDates);
+      }
     }
-  
-    /**
-     * Converts a single (possibly incomplete) EDTF date to a Solr-compatible format.
-     */
-    protected function convertEDTFtoSolr($value)
-    {
-        // Sanitize and normalize the EDTF string.
-        $value = $this->sanitizeEDTFString($value);
-        $value = $this->normalizeXPlaceholders($value);
-  
-        // Handle season mapping for YYYY-MM format if applicable.
-        if (preg_match('/^(\d{4})-(\d{2})$/', $value, $matches)) {
-            $year = $matches[1];
-            $month = $matches[2];
-            if (isset(EDTFUtils::SEASONS_MAP[$month])) {
-                $mapped_month = EDTFUtils::SEASONS_MAP[$month];
-                return "{$year}-{$mapped_month}-01T00:00:00Z";
-            }
+  }
+
+  /**
+   * Checks if the provided value is a single (possibly incomplete) EDTF date.
+   *
+   * Accepted formats:
+   * - YYYY (e.g. "2012")
+   * - YYYY-MM (e.g. "2012-05")
+   * - YYYY-MM-DD (e.g. "2012-05-01")
+   *
+   * Allows X placeholders.
+   */
+  protected function isSingleEdtfDate($value) {
+    if (!is_string($value)) {
+      return FALSE;
+    }
+    if (preg_match('/^\.\.\/(.+)/', $value, $matches)) {
+      $start_year = !empty($this->configuration['open_start_year'])
+                ? $this->configuration['open_start_year']
+                : '1000';
+      $value = $start_year . '/' . $matches[1];
+    }
+    if (preg_match('/(.+)\/\.\.$/', $value, $matches)) {
+      $end_year = !empty($this->configuration['open_end_year'])
+                ? $this->configuration['open_end_year']
+                : '9999';
+      $value = $matches[1] . '/' . $end_year;
+    }
+    /* Check for EDTF date with a range (e.g. "YYYY/YYYY") */
+    if (strpos($value, '/') !== FALSE) {
+      $parts = explode('/', $value);
+      $value = trim($parts[0]);
+    }
+    /* Check for extended year notation: value starting with 'Y' */
+    if (strpos($value, 'Y') === 0) {
+      $candidate = substr($value, 1);
+      return preg_match('/^-?[0-9]{5,}$/', $candidate);
+    }
+    return preg_match('/^[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?$/', $value);
+  }
+
+  /**
+   * Checks if is multiple EDTF date value (wrapped in curly braces).
+   *
+   * Accepted format:
+   * - {YYYY, YYYY-MM, YYYY-MM-DD, ...}
+   */
+  protected function isEdtfMultiDate($value) {
+    return is_string($value) && preg_match('/^{\s*([0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)(\s*,\s*[0-9X]{4}(-[0-9X]{2}(-[0-9X]{2})?)?)*\s*}$/', $value);
+  }
+
+  /**
+   * Converts a single EDTF date to a Solr-compatible format.
+   */
+  protected function convertEdtftoSolr($value) {
+    if (preg_match('/^\.\.\/(.+)/', $value, $matches)) {
+      $start_year = !empty($this->configuration['open_start_year'])
+                ? $this->configuration['open_start_year']
+                : '1000';
+      $value = $start_year . '/' . $matches[1];
+    }
+
+    if (preg_match('/(.+)\/\.\.$/', $value, $matches)) {
+      $end_year = !empty($this->configuration['open_end_year'])
+                ? $this->configuration['open_end_year']
+                : '9999';
+      $value = $matches[1] . '/' . $end_year;
+    }
+
+    if (strpos($value, '/') !== FALSE) {
+      $parts = explode('/', $value);
+      $value = trim($parts[0]);
+    }
+
+    if (strpos($value, 'Y') === 0) {
+      $value = substr($value, 1);
+    }
+
+    // Sanitize and normalize the EDTF string.
+    $value = $this->sanitizeEdtfString($value);
+    $value = $this->normalizePlaceholders($value);
+
+    // Validate numeric constraints.
+    $parts = explode('-', $value);
+    if (count($parts) >= 2) {
+      $month = (int) $parts[1];
+      if ($month < 1 || $month > 12) {
+        \Drupal::logger('edtf_date_processor')->warning('Month out of acceptable range in date: "@value". Month should be between 01 and 12.', ['@value' => $value]);
+      }
+    }
+    if (count($parts) == 3) {
+      $day = (int) $parts[2];
+      if ($day < 1 || $day > 31) {
+        \Drupal::logger('edtf_date_processor')->warning('Day out of acceptable range in date: "@value". Day should be between 01 and 31.', ['@value' => $value]);
+      }
+    }
+
+    // Ensure complete date format.
+    switch (TRUE) {
+      case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
+        break;
+
+      case preg_match('/^\d{4}-\d{2}$/', $value):
+        $value .= '-01';
+        break;
+
+      case preg_match('/^\d{4}$/', $value):
+        $value .= '-01-01';
+        break;
+
+      // Handle extended year notation (e.g. "YYYYY").
+      case preg_match('/^-?[0-9]{5,}$/', $value):
+        $value .= '-01-01';
+        \Drupal::logger('edtf_date_processor')->warning('This is an extended year date, this might parse unexpectedly and cause issues.');
+        break;
+    }
+    // Check if the date is the expected format after appending missing parts.
+    if (!preg_match('/^-?\d{4}-\d{2}-\d{2}$/', $value)) {
+      \Drupal::logger('edtf_date_processor')->warning('Date value after appending missing parts does not match the expected pattern: "@value".', ['@value' => $value]);
+    }
+
+    return $value . 'T00:00:00Z';
+  }
+
+  /**
+   * Converts a multiple EDTF date value to an array of Solr-compatible dates.
+   */
+  protected function convertEdtfMultiDateToSolr($value) {
+    if (preg_match_all('/[0-9X]{4}(?:-[0-9X]{2}(?:-[0-9X]{2})?)?/', $value, $matches)) {
+      $converted = [];
+      foreach ($matches[0] as $raw_date) {
+        $converted[] = $this->convertEdtftoSolr($raw_date);
+      }
+      return $converted;
+    }
+    return [];
+  }
+
+  /**
+   * Removes unwanted special characters from the EDTF string.
+   */
+  protected function sanitizeEdtfString($value) {
+    return str_replace(["~", "?", "%"], "", $value);
+  }
+
+  /**
+   * Replaces X placeholders in the EDTF string.
+   *
+   * For the year, replaces all X with 0.
+   * For month/day, replaces "XX" with "01".
+   */
+  protected function normalizePlaceholders($value) {
+    $parts = explode('-', $value);
+    $parts[0] = str_replace('X', '0', $parts[0]);
+    if (isset($parts[1])) {
+      if ($parts[1] === 'XX') {
+        $parts[1] = '01';
+      }
+      else {
+        $parts[1] = str_replace('X', '0', $parts[1]);
+        if ($parts[1] === '00') {
+          $parts[1] = '01';
         }
-  
-        // Ensure complete date format.
-        switch (true) {
-        case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
-            break;
-        case preg_match('/^\d{4}-\d{2}$/', $value):
-            $value .= '-01';
-            break;
-        case preg_match('/^\d{4}$/', $value):
-            $value .= '-01-01';
-            break;
-        }
-        return $value . 'T00:00:00Z';
+      }
     }
-  
-    /**
-     * Converts a multiple EDTF date value to an array of Solr-compatible dates.
-     */
-    protected function convertEDTFMultiDateToSolr($value)
-    {
-        if (preg_match_all('/[0-9X]{4}(?:-[0-9X]{2}(?:-[0-9X]{2})?)?/', $value, $matches)) {
-            $converted = [];
-            foreach ($matches[0] as $raw_date) {
-                $converted[] = $this->convertEDTFtoSolr($raw_date);
-            }
-            return $converted;
+    if (isset($parts[2])) {
+      if ($parts[2] === 'XX') {
+        $parts[2] = '01';
+      }
+      else {
+        $parts[2] = str_replace('X', '0', $parts[2]);
+        if ($parts[2] === '00') {
+          $parts[2] = '01';
         }
-        return [];
+      }
     }
-  
-    /**
-     * Removes unwanted special characters from the EDTF string.
-     */
-    protected function sanitizeEDTFString($value)
-    {
-        return str_replace(["~", "?", "%"], "", $value);
-    }
-  
-    /**
-     * Replaces X placeholders in the EDTF string.
-     *
-     * For the year, replaces all X with 0.
-     * For month/day, replaces "XX" with "01", else replaces X with 0 and fixes "00" to "01".
-     */
-    protected function normalizeXPlaceholders($value)
-    {
-        $parts = explode('-', $value);
-        $parts[0] = str_replace('X', '0', $parts[0]);
-        if (isset($parts[1])) {
-            if ($parts[1] === 'XX') {
-                $parts[1] = '01';
-            }
-            else {
-                $parts[1] = str_replace('X', '0', $parts[1]);
-                if ($parts[1] === '00') {
-                    $parts[1] = '01';
-                }
-            }
-        }
-        if (isset($parts[2])) {
-            if ($parts[2] === 'XX') {
-                $parts[2] = '01';
-            }
-            else {
-                $parts[2] = str_replace('X', '0', $parts[2]);
-                if ($parts[2] === '00') {
-                    $parts[2] = '01';
-                }
-            }
-        }
-        return implode('-', $parts);
-    }
+    return implode('-', $parts);
+  }
+
 }

--- a/src/Plugin/search_api/processor/EDTFDateProcessor.php
+++ b/src/Plugin/search_api/processor/EDTFDateProcessor.php
@@ -63,10 +63,12 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
         $fields_options = [];
         foreach ($fields as $field) {
             $key = $field->getTargetEntityTypeId() . '|' . $field->getName();
-            $fields_options[$key] = $this->t('@label (Entity: @entity_type)', [
+            $fields_options[$key] = $this->t(
+                '@label (Entity: @entity_type)', [
                 '@label' => $field->label(),
                 '@entity_type' => $field->getTargetEntityTypeId(),
-            ]);
+                ]
+            );
         }
   
         $form['fields'] = [
@@ -132,14 +134,16 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
                 ->setLabel($this->t('EDTF Dates'))
                 ->setDescription($this->t('Indexes single EDTF dates or multiple separate dates.'));
         
-            $properties['edtf_dates'] = new ProcessorProperty([
+            $properties['edtf_dates'] = new ProcessorProperty(
+                [
                 'label' => $this->t('EDTF Dates'),
                 'description' => $this->t('Indexes single EDTF dates or multiple separate dates.'),
                 'type' => 'datetime_iso8601',
                 'is_list' => true,
                 'processor_id' => $this->getPluginId(),
                 'data_definition' => $data_definition,
-            ]);
+                ]
+            );
         }
   
         return $properties;
@@ -198,9 +202,11 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
         $edtfDates = $filteredDates;
   
         // Sort dates in ascending order.
-        usort($edtfDates, function ($a, $b) {
-            return strtotime($a) - strtotime($b);
-        });
+        usort(
+            $edtfDates, function ($a, $b) {
+                return strtotime($a) - strtotime($b);
+            }
+        );
   
         if (!empty($edtfDates)) {
             $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), null, 'edtf_dates');
@@ -257,14 +263,14 @@ class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterfa
   
         // Ensure complete date format.
         switch (true) {
-            case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
-                break;
-            case preg_match('/^\d{4}-\d{2}$/', $value):
-                $value .= '-01';
-                break;
-            case preg_match('/^\d{4}$/', $value):
-                $value .= '-01-01';
-                break;
+        case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
+            break;
+        case preg_match('/^\d{4}-\d{2}$/', $value):
+            $value .= '-01';
+            break;
+        case preg_match('/^\d{4}$/', $value):
+            $value .= '-01-01';
+            break;
         }
         return $value . 'T00:00:00Z';
     }

--- a/src/Plugin/search_api/processor/EDTFDateProcessor.php
+++ b/src/Plugin/search_api/processor/EDTFDateProcessor.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\search_api\processor;
+
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\search_api\Plugin\PluginFormTrait;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+
+/**
+ * Provides a Search API processor for indexing EDTF dates (single and multiple dates) in Solr.
+ *
+ * @SearchApiProcessor(
+ *   id = "edtf_date_processor",
+ *   label = @Translation("EDTF Date Processor"),
+ *   description = @Translation("Indexes EDTF dates (single or multiple) as Solr Date Types."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   }
+ * )
+ */
+class EDTFDateProcessor extends ProcessorPluginBase implements PluginFormInterface
+{
+    use PluginFormTrait;
+    use StringTranslationTrait;
+  
+    /**
+     * @var array Stores plugin configuration 
+     */
+    protected $configuration;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function defaultConfiguration()
+    {
+        return [
+        'fields' => [],
+        'ignore_open_start' => false,
+        'ignore_open_end' => false,
+        'open_start_year' => 0,
+        'open_end_year' => '',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildConfigurationForm(array $form, FormStateInterface $form_state)
+    {
+        $form['#description'] = $this->t('Select the EDTF fields to extract dates from.');
+
+        $fields = \Drupal::entityTypeManager()
+            ->getStorage('field_config')
+            ->loadByProperties(['field_type' => 'edtf']);
+
+        $fields_options = [];
+        foreach ($fields as $field) {
+            $key = $field->getTargetEntityTypeId() . '|' . $field->getName();
+            $fields_options[$key] = $this->t(
+                '@label (Entity: @entity_type)', [
+                '@label' => $field->label(),
+                '@entity_type' => $field->getTargetEntityTypeId(),
+                ]
+            );
+        }
+
+        $form['fields'] = [
+        '#type' => 'select',
+        '#multiple' => true,
+        '#title' => $this->t('EDTF Fields'),
+        '#description' => $this->t('Select one or more EDTF fields to index.'),
+        '#options' => $fields_options,
+        '#default_value' => $this->configuration['fields'],
+        ];
+
+        $form['open_start_year'] = [
+        '#type' => 'number',
+        '#title' => $this->t('Open Interval Begin Year'),
+        '#description' => $this->t('Sets the begging year to begin indexing from. Leave blank if you would like to index from the smallest year found in the data.'),
+        '#default_value' => $this->configuration['open_start_year'],
+        ];
+        $form['open_end_year'] = [
+        '#type' => 'number',
+        '#title' => $this->t('Open Interval End Year'),
+        '#description' => $this->t('Sets the end year to end indexing at. Leave blank if you would like to indext to the largest year found in the data.'),
+        '#default_value' => $this->configuration['open_end_year'],
+        ];
+
+        return $form;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateConfigurationForm(array &$form, FormStateInterface $form_state)
+    {
+        if ($form_state->getValue('open_start_year') < 0) {
+            $form_state->setErrorByName('open_start_year', $this->t('Open start year must be a positive integer.'));
+        }
+    
+        if (!empty($form_state->getValue('open_end_year')) && $form_state->getValue('open_end_year') < $form_state->getValue('open_start_year')) {
+            $form_state->setErrorByName('open_end_year', $this->t('Open end year must be greater than or equal to open start year.'));
+        }
+    }
+  
+
+    /**
+     * {@inheritdoc}
+     */
+    public function submitConfigurationForm(array &$form, FormStateInterface $form_state)
+    {
+        $this->configuration['fields'] = $form_state->getValue('fields', []);
+        $this->configuration['ignore_open_start'] = $form_state->getValue('ignore_open_start');
+        $this->configuration['ignore_open_end'] = $form_state->getValue('ignore_open_end');
+        $this->configuration['open_start_year'] = $form_state->getValue('open_start_year');
+        $this->configuration['open_end_year'] = $form_state->getValue('open_end_year');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertyDefinitions(?DatasourceInterface $datasource = null)
+    {
+        $properties = [];
+    
+        if (!$datasource) {
+            $data_definition = \Drupal::typedDataManager()->createDataDefinition('datetime_iso8601')
+                ->setLabel($this->t('EDTF Dates'))
+                ->setDescription($this->t('Indexes single EDTF dates or multiple separate dates.'));
+        
+            $properties['edtf_dates'] = new ProcessorProperty(
+                [
+                'label' => $this->t('EDTF Dates'),
+                'description' => $this->t('Indexes single EDTF dates or multiple separate dates.'),
+                'type' => 'datetime_iso8601',
+                'is_list' => true,
+                'processor_id' => $this->getPluginId(),
+                'data_definition' => $data_definition,
+                ]
+            );
+        }
+
+        return $properties;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldValues(ItemInterface $item)
+    {
+        $entity = $item->getOriginalObject()->getValue();
+        $edtfDates = [];
+
+        foreach ($this->configuration['fields'] as $field_key) {
+            if (strpos($field_key, '|') === false) {
+                continue;
+            }      
+            [$entity_type, $field_name] = explode('|', $field_key, 2);
+            if ($entity->getEntityTypeId() !== $entity_type) {
+                continue;
+            }
+            if (!$entity->hasField($field_name)) {
+                continue;
+            }
+      
+            $field_values = $entity->get($field_name)->getValue();
+            foreach ($field_values as $date_item) {
+                if (!empty($date_item['value'])) {
+                    $value = $date_item['value'];
+
+                    if ($this->isSingleEDTFDate($value)) {
+                        $edtfDates[] = $this->convertEDTFtoSolr($value);
+                    }
+                    elseif ($this->isEDTFMultiDate($value)) {
+                        $dates = $this->convertEDTFMultiDateToSolr($value);
+                        if ($dates) {
+                            $edtfDates = array_merge($edtfDates, $dates);
+                        }
+                    }
+                }
+            }
+        }
+        $filteredDates = [];
+        foreach ($edtfDates as $date) {
+            $year = (int) substr($date, 0, 4);
+            if (!$this->configuration['ignore_open_start'] && $this->configuration['open_start_year'] > 0 && $year < $this->configuration['open_start_year']) {
+                continue;
+            }
+            if (!$this->configuration['ignore_open_end'] && !empty($this->configuration['open_end_year']) && $year > $this->configuration['open_end_year']) {
+                continue;
+            }
+            $filteredDates[] = $date;
+        }
+        $edtfDates = $filteredDates;
+
+        // Sort dates in ascending order.
+        usort(
+            $edtfDates, function ($a, $b) {
+                return strtotime($a) - strtotime($b);
+            }
+        );
+
+        if (!empty($edtfDates)) {
+            $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), null, 'edtf_dates');
+            foreach ($fields as $field) {
+                $field->setValues($edtfDates);
+            }
+        }
+    }
+
+    /**
+     * Checks if the provided value is a single (possibly incomplete) EDTF date.
+     *
+     * Accepted formats:
+     * - YYYY (e.g. "2012")
+     * - YYYY-MM (e.g. "2012-05")
+     * - YYYY-MM-DD (e.g. "2012-05-01")
+     */
+    protected function isSingleEDTFDate($value)
+    {
+        return (bool) preg_match('/^\d{4}(-\d{2}(-\d{2})?)?$/', $value);
+    }
+
+    /**
+     * Checks if the provided value is a multiple EDTF date value (wrapped in curly braces).
+     */
+    protected function isEDTFMultiDate($value)
+    {
+        return is_string($value) && preg_match('/^{\s*(\d{4}-\d{2}-\d{2})(\s*,\s*\d{4}-\d{2}-\d{2})*\s*}$/', $value);
+    }
+
+    /**
+     * Converts a single (possibly incomplete) EDTF date to Solr-compatible format.
+     */
+    protected function convertEDTFtoSolr($value)
+    {
+        switch (true) {
+        case preg_match('/^\d{4}-\d{2}-\d{2}$/', $value):
+            break;
+        case preg_match('/^\d{4}-\d{2}$/', $value):
+            $value .= '-01';
+            break;
+        case preg_match('/^\d{4}$/', $value):
+            $value .= '-01-01';
+            break;
+        }
+        return $value . 'T00:00:00Z';
+    }
+
+    /**
+     * Converts a multiple EDTF date value to an array of Solr-compatible dates.
+     */
+    protected function convertEDTFMultiDateToSolr($value)
+    {
+        if (preg_match_all('/\d{4}-\d{2}-\d{2}/', $value, $matches)) {
+            return array_map(
+                function ($date) {
+                    return $date . 'T00:00:00Z';
+                }, $matches[0]
+            );
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
**GitHub Issue**:  #140 

# What does this Pull Request do?

This PR introduces the updated EDTF Date Processor code to index full EDTF dates (including partial or multiple dates) in Solr, rather than just extracting the year. It consolidates date logic within the controlled_access_terms module, enabling more precise date-based sorting and filtering in Drupal’s Search API.

# What's new?
Adds a new EDTFDateProcessor class that:

- Converts complete or incomplete single EDTF dates (e.g., 2012, 2012-05, 2012-05-03) into a complete date for Solr (YYYY-01-01T00:00:00Z, YYYY-MM-01T00:00:00Z, YYYY-MM-DDT00:00:00Z, etc.).
- Supports multiple dates (e.g., {2012-01-01, 2012-04-15}) by splitting them into separate Solr date values.
- Filters out dates outside configured open interval years (open_start_year, open_end_year) if specified.

This change does not introduce new dependencies but does require updating the search index configuration to use this processor.

Existing code dealing strictly with “year-only” fields remains unaffected.


# How should this be tested?

1. **Enable EDTF Date Processor**  
   - In Drupal, go to **Extend**
   - Locate the **Controlled Access Terms** module (which now contains the EDTF Date Processor).
   - Enable it if it’s not already enabled.

2. **Configure the Processor Settings**  
   - Navigate to **Search API → Your Index → Processors** 
   - Enable the **EDTF Date Processor**.
   - Scroll to the **EDTF Date Processor** settings form near the bottom of the page.
   - Choose your preferred configuration options (similar to how you set up the EDTFYear processor)

3. **Add the `edtf_dates` Field to Your Index**  
   - Still under **Search API → Your Index**, click **Fields**
   - Click **Add fields** and look for **EDTF Dates** (listed under **EDTF Date Processor**).
   - Check the box next to `edtf_dates` and save.
   - This ensures Solr (or whichever backend) knows to store and index these date values.

4. **Enter Test Content with Various EDTF Formats**  
   - Go to any content type that uses an **EDTF** field (as configured in step 2).
   - Add or edit content, then set the **EDTF** field to one of the following:

     1. **Single Complete Date: `2012-12-12`**  
        - Should index as `2012-12-12T00:00:00Z` in `edtf_dates`.
     2. **Missing Day: `2012-12`**  
        - Should index as `2012-12-01T00:00:00Z`.
     3. **Missing Month and Day: `2012`**  
        - Should index as `2012-01-01T00:00:00Z`.
     4. **Multiple Dates: `{2013-12-12, 2014-09-09}`**  
        - Should split into two entries:  
          - `2013-12-12T00:00:00Z`  
          - `2014-09-09T00:00:00Z`  
        - Both values should appear in ascending order in `edtf_dates`.

5. **Check the Indexed Results in Solr**  
   - After saving your content, run a **re-index** of your Search API index (if necessary).
   - In the **Solr Admin UI** or via a Solr query, verify the `edtf_dates` field for the content item.
   - You should see all indexed dates, sorted in ascending order.
   
# Additional Notes:

- **Sets for Multiple Dates:**  
  If you wish to allow multiple dates (e.g., `{2013-12-12, 2014-09-09}`), ensure your EDTF field is configured to accept sets. The EDTF Date Processor will then index each date separately into the `edtf_dates` array.  

- **Merged Dates from Multiple Fields:**  
  For each field you configure in the **EDTF Date Processor** settings, all valid dates found are added to `edtf_dates`, sorted in ascending order. This means if multiple EDTF fields are selected, the resulting `edtf_dates` field will contain dates from all of them.  

- **Sorting by edtf_dates:**  
  If you configure your index or views to sort by `edtf_dates`, the **earliest date** (i.e., the first element in the sorted `edtf_dates` array) determines the sort order.  

- **Open Interval Settings:**  
  If you specify a start year (`open_start_year`) and end year (`open_end_year`), any dates falling outside that range (and not ignored by your configuration) will be excluded from `edtf_dates`. This can help narrow the indexed date range if you only need a specific window of time.  
 
# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
@Islandora/committers

