### PR TITLE
Setting a basic EDTF year field value when using devel_generate to generate sample data.

### DIFF
--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -26,7 +26,7 @@ class ExtendedDateTimeFormat extends StringItem {
    */
   public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
     // Setting a valid basic EDTF year value.
-    $values = (string)mt_rand(0, 9999);
+    $values = (string)mt_rand(1600, 9999);
     return $values;
   }
 }

--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -21,4 +21,12 @@ use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
  */
 class ExtendedDateTimeFormat extends StringItem {
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
+    // Setting a valid basic EDTF year value.
+    $values = (string)mt_rand(0, 9999);
+    return $values;
+  }
 }

--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\controlled_access_terms\Plugin\Field\FieldType;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
 
 /**

--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -26,7 +26,8 @@ class ExtendedDateTimeFormat extends StringItem {
    */
   public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
     // Setting a valid basic EDTF year value.
-    $values = (string)mt_rand(1600, 9999);
+    $values = (string) mt_rand(1600, 9999);
     return $values;
   }
+
 }


### PR DESCRIPTION
# What does this Pull Request do?
Generates a valid EDTF value for a EDTF Typed field when using `devel_generate`. Currently a random string value will be generated instead. 

# How should this be tested?
- Enable the `devel_generate` module via `/admin/modules` admin menu
- Enable `Generate` within the devel configuration `/admin/config/development/devel/toolbar` admin menu
- Create a field on the islandora content type that uses the `EDTF` field type.
- Use `Generate` to generate content of type `Repository Item`
- Data for the field should now be a value between 1600 and 9999 instead of a random string.

# Interested parties
@Islandora/committers
