### PR TITLE
depend on functionality instead of ui module

### DIFF
--- a/modules/controlled_access_terms_defaults/controlled_access_terms_defaults.info.yml
+++ b/modules/controlled_access_terms_defaults/controlled_access_terms_defaults.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - drupal:content_translation
   - drupal:field
   - drupal:language
-  - drupal:menu_ui
+  - drupal:menu_link_content
   - drupal:node
   - drupal:options
   - drupal:path


### PR DESCRIPTION
**GitHub Issue**: [related to the PR in the islandora module](https://github.com/Islandora/islandora/pull/1080)

# What does this Pull Request do?

The `menu_link_content` module is the underlying functionality module for `menu_ui`. Depending on that instead.