### PR TITLE
fix: make seasonal EDTF dates display properly in item metadata

### DIFF
--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -263,9 +263,17 @@ class EDTFFormatter extends FormatterBase {
     }
 
     if (array_key_exists(EDTFUtils::MONTH, $parsed_date)) {
+      // determining whether the month is seasonal
+      $int_month_value = intval($parsed_date[EDTFUtils::MONTH]);
+      $is_seasonal = ($int_month_value >= 21) && ($int_month_value <= 41);
+
       if (strpos($parsed_date[EDTFUtils::MONTH], 'X') !== FALSE) {
         $unspecified['month'] = TRUE;
         $unspecified_count++;
+      }
+      // convert seasonal months to 'mmmm'
+      else if ($is_seasonal){
+        $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]]['mmmm'];
       }
       elseif ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
         $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]][$settings['month_format']];
@@ -443,6 +451,12 @@ class EDTFFormatter extends FormatterBase {
           "@year" => $year,
         ]);
       }
+    }
+    // change the display format if the month is seasonal to be always (month [space] year)
+    else if ($is_seasonal){
+        $formatted_date = t("@date", [
+            "@date" => implode(self::DELIMITERS['space'], array_filter([$month, $year])),
+        ]);
     }
     else {
       $formatted_date = t("@date", [

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -87,6 +87,7 @@ class EDTFFormatter extends FormatterBase {
         'm' => t('one-digit month for months below 10, e.g. 4'),
         'mmm' => t('three-letter abbreviation for month, Apr'),
         'mmmm' => t('month spelled out in full, e.g. April'),
+        'num_seasonal' => t('numbered months (e.g. 01) and seasons spelled out in full (e.g. Spring)'),
       ],
     ];
     $form['day_format'] = [
@@ -223,6 +224,9 @@ class EDTFFormatter extends FormatterBase {
     $month = '';
     $day = '';
 
+    // flag to keep track of the seasons
+    $is_seasonal = FALSE;
+
     preg_match(EDTFUtils::DATE_PARSE_REGEX, $date_time[0], $parsed_date);
 
     // Expand the year if the Year Exponent exists.
@@ -271,8 +275,8 @@ class EDTFFormatter extends FormatterBase {
         $unspecified['month'] = TRUE;
         $unspecified_count++;
       }
-      // convert seasonal months to 'mmmm'
-      else if ($is_seasonal){
+      // spell out seasons in full, but keep the regular months (1-12) as numbers
+      elseif ($is_seasonal && $settings['month_format'] === 'num_seasonal'){
         $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]]['mmmm'];
       }
       elseif ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
@@ -452,8 +456,9 @@ class EDTFFormatter extends FormatterBase {
         ]);
       }
     }
-    // change the display format if the month is seasonal to be always (month [space] year)
-    else if ($is_seasonal){
+    // change the display format to be always (month [space] year)
+    // if the month is seasonal and the user has selected the appropriate setting 'num_seasonal'
+    if ($is_seasonal && $settings['month_format'] === 'num_seasonal'){
         $formatted_date = t("@date", [
             "@date" => implode(self::DELIMITERS['space'], array_filter([$month, $year])),
         ]);

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -224,7 +224,7 @@ class EDTFFormatter extends FormatterBase {
     $month = '';
     $day = '';
 
-    // flag to keep track of the seasons
+    // Flag to keep track of the seasons.
     $is_seasonal = FALSE;
 
     preg_match(EDTFUtils::DATE_PARSE_REGEX, $date_time[0], $parsed_date);
@@ -267,7 +267,7 @@ class EDTFFormatter extends FormatterBase {
     }
 
     if (array_key_exists(EDTFUtils::MONTH, $parsed_date)) {
-      // determining whether the month is seasonal
+      // Determining whether the month is seasonal.
       $int_month_value = intval($parsed_date[EDTFUtils::MONTH]);
       $is_seasonal = ($int_month_value >= 21) && ($int_month_value <= 41);
 
@@ -275,8 +275,8 @@ class EDTFFormatter extends FormatterBase {
         $unspecified['month'] = TRUE;
         $unspecified_count++;
       }
-      // spell out seasons in full, but keep the regular months (1-12) as numbers
-      elseif ($is_seasonal && $settings['month_format'] === 'num_seasonal'){
+      // Spell out seasons in full, keep the regular months (1-12) as numbers.
+      elseif ($is_seasonal && $settings['month_format'] === 'num_seasonal') {
         $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]]['mmmm'];
       }
       elseif ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
@@ -456,16 +456,18 @@ class EDTFFormatter extends FormatterBase {
         ]);
       }
     }
-    // change the display format to be always (month [space] year)
-    // if the month is seasonal and the user has selected the appropriate setting 'num_seasonal'
-    if ($is_seasonal && $settings['month_format'] === 'num_seasonal'){
-        $formatted_date = t("@date", [
-            "@date" => implode(self::DELIMITERS['space'], array_filter([$month, $year])),
-        ]);
+    // Change the display format to be always (month [space] year).
+    // If month is seasonal and the user has selected 'num_seasonal'.
+    if ($is_seasonal && $settings['month_format'] === 'num_seasonal') {
+      $space = self::DELIMITERS['space'];
+      $formatted_date = t("@date", [
+        "@date" => implode($space, array_filter([$month, $year])),
+      ]);
     }
     else {
+      $date_separator = self::DELIMITERS[$settings['date_separator']];
       $formatted_date = t("@date", [
-        "@date" => implode(self::DELIMITERS[$settings['date_separator']], array_filter($parts_in_order)),
+        "@date" => implode($date_separator, array_filter($parts_in_order)),
       ]);
     }
 


### PR DESCRIPTION
**Closes #153**

# What does this Pull Request do?
This PR fixes the bug where EDTF seasonal codes (21-41) were displayed as raw numeric values (e.g. **1981-21**) in the item metadata. It ensures that these codes are now translated into human-readable strings (e.g. **Spring 1981** for **1981-21**) as per the EDTF standards.

# What's new?
- Modified *EDTFFormatter.php* (*formatDate()* method) to detect seasonal codes and map numeric codes to their respective names via *MONTHS_MAP* from *EDTFUtils.php*.
- Updated the display to always display a "Month [space] Year" format for better readability.
- Does this change require documentation to be updated? 
No (this is only a display fix since we already have support for EDTF)
- Does this change add any new dependencies? 
No
- Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
No
- Could this change impact execution of existing code?
No (it only changes how the seasonal dates are displayed)

# How should this be tested?
1. Reproduce the issue: On an islandora site, edit any item and enter a seasonal date such as **1981-21** into an EDTF date field. If you view the item, it will display **1981-21** (raw month code)
2. Apply this PR
3. Test with changes: 
- Go to the same item (as in Step 1), and now it should display **Spring 1981**.
- Test with edge cases as well. For example, **1981-23?** should display **Autumn 1981 (year and month uncertain)**.

# Additional Notes:
The PR forces a "Month [space] Year" order for because it makes more sense to use it over standard "Big-endian" formatting (Year-Month) (i.e., **Spring 1981** is preferred over **1981 Spring**).
