### PR TITLE
make qualifiers translatable

### DIFF
--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -597,21 +597,40 @@ class EDTFFormatter extends FormatterBase {
       }
     }
     $qualifier_parts = [];
+    $part_labels = [
+      'year' => $this->t('year'),
+      'month' => $this->t('month'),
+      'day' => $this->t('day'),
+    ];
+    $qualifier_labels = [
+      'uncertain' => $this->t('uncertain'),
+      'approximate' => $this->t('approximate'),
+    ];
+
     foreach ($qualifiers as $qualifier => $parts) {
       $keys = array_keys($parts);
       switch (count($keys)) {
         case 1:
         case 2:
-          $qualifier_parts[] = implode(' ' . $this->t('and') . ' ', $keys) . ' ' . $qualifier;
+          $translated_parts = array_map(function ($key) use ($part_labels) {
+            return $part_labels[$key];
+          }, $keys);
+          $qualifier_parts[] = $this->t('@parts @qualifier', [
+            '@parts' => implode(' ' . $this->t('and') . ' ', $translated_parts),
+            '@qualifier' => $qualifier_labels[$qualifier],
+          ]);
           break;
 
         case 3:
-          $qualifier_parts[] = $qualifier;
+          $qualifier_parts[] = $qualifier_labels[$qualifier];
           break;
       }
     }
     if (count($qualifier_parts) > 0) {
-      return $formatted_date . ' (' . implode('; ', $qualifier_parts) . ')';
+      return $this->t('@date (@qualifiers)', [
+        '@date' => $formatted_date,
+        '@qualifiers' => implode('; ', $qualifier_parts),
+      ]);
     }
     return $formatted_date;
   }


### PR DESCRIPTION
**GitHub Issue**: (link)
The EDTF Field formatter terms such as uncertain and approximate are currently cannot be translated via Drupal UI.

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
This PR makes the qualifier terms related to EDTF Field formatter translatable. 

# What's new?
Makes the qualifier terms as translatable variables.

# How should this be tested?
* Add a language to the Drupal (admin/config/regional/language) if it only has one language.  Also enable User interface translation.
* Create repository items with values such as 2000~, 2000?, 2000-01~, 2000-01?, 2000-01-22~, 2000-01-22? in the source language
* Switch the language, the qualifier terms such as approximate and uncertain will be in the source language
* Pull the PR, cache clear
* Go to the target language.  This will register the terms that need to be translated.
* Go to  User interface translation (`admin/config/regional/translate`), search for the term, and provide the translated terms.
* Go back to the item in the target language.  It should show the translated field formatter label. 
* Alternatively, you can export the po file containing the current translation ids and strings and add the required translations (year, month, day, uncertain, approximate)

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
