### PR TITLE
#3595143 Add Typed Relation 'raw' formatter to expose rel_type and target_id

### DIFF
--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatterRaw.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatterRaw.php
@@ -25,7 +25,7 @@ class TypedRelationFormatterRaw extends EntityReferenceLabelFormatter {
     $elements = parent::viewElements($items, $langcode);
 
     foreach ($items as $delta => $item) {
-        $elements[$delta]['#plain_text'] = $item->rel_type . '=' . $item->target_id;
+      $elements[$delta]['#plain_text'] = $item->rel_type . '=' . $item->target_id;
     }
 
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/TypedRelationFormatterRaw.php
+++ b/src/Plugin/Field/FieldFormatter/TypedRelationFormatterRaw.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\controlled_access_terms\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+
+/**
+ * Formatter to output raw values, e.g. rel_type=target_id.
+ *
+ * @FieldFormatter(
+ *   id = "typed_relation_raw",
+ *   label = @Translation("Typed Relation Formatter (Raw)"),
+ *   field_types = {
+ *     "typed_relation"
+ *   }
+ * )
+ */
+class TypedRelationFormatterRaw extends EntityReferenceLabelFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = parent::viewElements($items, $langcode);
+
+    foreach ($items as $delta => $item) {
+        $elements[$delta]['#plain_text'] = $item->rel_type . '=' . $item->target_id;
+    }
+
+    return $elements;
+  }
+
+}


### PR DESCRIPTION
[#3595143](https://www.drupal.org/project/controlled_access_terms/issues/3595143) Add Typed Relation 'raw' formatter to expose rel_type and target_id

**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Offers new Typed Relation formatter "Typed Relation Formatter (Raw)" that exposes 'raw' `rel_type` and `target_id` data, e.g. `relators:art=1234` suitable for audit view, or export and import processes.

# How should this be tested?
1. Apply patch/PR
2. Visit view involving entities with typed relations
3.  Change view field display to sue "Typed Relation Formatter (Raw)"
4. Observe 'raw' data output in view preview.

# Interested parties
@Islandora/committers
